### PR TITLE
added pkg/compiler/rego

### DIFF
--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -1,0 +1,33 @@
+package compiler
+
+import (
+	"fmt"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/compiler/error"
+)
+
+// compiler defines the interface for the language specific compiler backends
+type Compiler interface {
+	// Compile compiles a set of policies into a string
+	Compile(pkgname string, pols *ast.Policies) (string, error)
+}
+
+// New creates a new compiler
+func New(language string) (Compiler, error) {
+	if len(language) <= 0 {
+		return nil, compiler_error.ErrEmptyLanguage
+	}
+
+	cnst := constructor(language)
+	if cnst == nil {
+		return nil, fmt.Errorf("invalid compiler language: %s", language)
+	}
+
+	cmp, err := cnst()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create compiler: %s", err)
+	}
+
+	return cmp, nil
+}

--- a/pkg/compiler/error/errors.go
+++ b/pkg/compiler/error/errors.go
@@ -1,0 +1,37 @@
+package compiler_error
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Errors ...
+var (
+	ErrEmptyLanguage    = errors.New("invalid empty language")
+	ErrEmptyPolicies    = errors.New("invalid empty policies")
+	ErrEmptySubject     = errors.New("invalid empty subject")
+	ErrInvalidSubject   = errors.New("invalid invalid subject")
+	ErrEmptyVerb        = errors.New("invalid empty verb")
+	ErrEmptyTypePattern = errors.New("invalid empty type-pattern")
+)
+
+// Error defines a compiler specific error type
+type Error struct {
+	Err  error
+	Line int
+	Desc string
+}
+
+// Error satisfies the error interface
+func (e *Error) Error() string {
+	return fmt.Sprintf("compiler_rego: at #%d %s due to error: %s", e.Line, e.Desc, e.Err)
+}
+
+// New is a convenience function to create an Error
+func New(err error, line int, desc string) *Error {
+	return &Error{
+		Err:  err,
+		Line: line,
+		Desc: desc,
+	}
+}

--- a/pkg/compiler/register.go
+++ b/pkg/compiler/register.go
@@ -1,0 +1,57 @@
+package compiler
+
+import (
+	"sort"
+	"sync"
+)
+
+var (
+	constructorsMu sync.RWMutex
+	constructors   = make(map[string]Constructor)
+)
+
+// Constructor defines the type for a compiler constructor
+type Constructor func() (Compiler, error)
+
+// Register makes a compiler constructor available for the specified language.
+// panic if Register is called twice with the same language or if compiler is nil
+func Register(language string, cnstr Constructor) {
+	constructorsMu.Lock()
+	defer constructorsMu.Unlock()
+	if len(language) <= 0 {
+		panic("compiler Register: language cannot be empty")
+	}
+	if cnstr == nil {
+		panic("compiler Register: constructor cannot be nil")
+	}
+	if _, dup := constructors[language]; dup {
+		panic("compiler Register: cannot be called twice for constructor of " + language)
+	}
+	constructors[language] = cnstr
+}
+
+func unregisterAllCompilers() {
+	constructorsMu.Lock()
+	defer constructorsMu.Unlock()
+	// For tests.
+	constructors = make(map[string]Constructor)
+}
+
+// Languages returns a sorted list of the language of the registered compiler constructors
+func Languages() []string {
+	constructorsMu.RLock()
+	defer constructorsMu.RUnlock()
+	list := make([]string, 0, len(constructors))
+	for language := range constructors {
+		list = append(list, language)
+	}
+	sort.Strings(list)
+	return list
+}
+
+// constructor returns the compiler constructor for a specific language
+func constructor(language string) Constructor {
+	constructorsMu.Lock()
+	defer constructorsMu.Unlock()
+	return constructors[language]
+}

--- a/pkg/compiler/rego/register.go
+++ b/pkg/compiler/rego/register.go
@@ -1,0 +1,14 @@
+package compiler_rego
+
+import (
+	"github.com/infobloxopen/seal/pkg/compiler"
+)
+
+// const...
+const (
+	Language = "rego"
+)
+
+func init() {
+	compiler.Register(Language, New)
+}

--- a/pkg/compiler/rego/rego.go
+++ b/pkg/compiler/rego/rego.go
@@ -1,0 +1,109 @@
+package compiler_rego
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/compiler"
+	"github.com/infobloxopen/seal/pkg/compiler/error"
+)
+
+// CompilerRego defines the compiler rego backend
+type CompilerRego struct{}
+
+// New creates a new compiler
+func New() (compiler.Compiler, error) {
+	return &CompilerRego{}, nil
+}
+
+// Compile converts the AST policies to a string
+func (c *CompilerRego) Compile(pkgname string, pols *ast.Policies) (string, error) {
+	if pols == nil {
+		return "", compiler_error.ErrEmptyPolicies
+	}
+
+	compiled := []string{
+		"",
+		fmt.Sprintf("package %s", pkgname),
+	}
+	for idx, stmt := range pols.Statements {
+		switch stmt.(type) {
+		case *ast.ActionStatement:
+			out, err := c.compileStatement(stmt.(*ast.ActionStatement))
+			if err != nil {
+				return "", compiler_error.New(err, idx, fmt.Sprintf("%s", stmt))
+			}
+			compiled = append(compiled, out)
+		}
+	}
+
+	return strings.Join(compiled, "\n"), nil
+}
+
+// compileStatement converts the AST statement to a string
+func (c *CompilerRego) compileStatement(stmt *ast.ActionStatement) (string, error) {
+	compiled := []string{fmt.Sprintf("%s = true {", stmt.Token.Literal)}
+
+	sub, err := c.compileSubject(stmt.Subject)
+	if err != nil {
+		return "", err
+	}
+	compiled = append(compiled, sub)
+
+	vrb, err := c.compileVerb(stmt.Verb)
+	if err != nil {
+		return "", err
+	}
+	compiled = append(compiled, vrb)
+
+	tp, err := c.compileTypePattern(stmt.TypePattern)
+	if err != nil {
+		return "", err
+	}
+	compiled = append(compiled, tp)
+
+	compiled = append(compiled, "}")
+	return strings.Join(compiled, "\n"), nil
+}
+
+// compileSubject converts the AST subject to a string
+func (c *CompilerRego) compileSubject(sub ast.Subject) (string, error) {
+	if sub == nil {
+		return "", compiler_error.ErrEmptySubject
+	}
+
+	switch t := sub.(type) {
+	case *ast.SubjectGroup:
+		return fmt.Sprintf("    `%s` in input.subject.groups", t.Group), nil
+	case *ast.SubjectUser:
+		return fmt.Sprintf("    input.subject.user == `%s`", t.User), nil
+	}
+
+	return "", compiler_error.ErrInvalidSubject
+}
+
+// compileVerb converts the AST verb to a string
+func (c *CompilerRego) compileVerb(vrb *ast.Identifier) (string, error) {
+	if vrb == nil {
+		return "", compiler_error.ErrEmptyVerb
+	}
+
+	return fmt.Sprintf("    input.verb == `%s`", vrb.Value), nil
+}
+
+// compileTypePattern converts the AST type pattern to a string
+func (c *CompilerRego) compileTypePattern(tp *ast.Identifier) (string, error) {
+	if tp == nil {
+		return "", compiler_error.ErrEmptyTypePattern
+	}
+
+	// TODO: optimize with list of registered types instead of regex
+	quoted := strings.ReplaceAll(tp.Value, "*", ".*")
+	return fmt.Sprintf("    re_match(`%s`, input.type)", quoted), nil
+}
+
+// String satifies stringer interface
+func (c *CompilerRego) String() string {
+	return fmt.Sprintf("compiler for %s language", Language)
+}

--- a/pkg/compiler/rego/rego_test.go
+++ b/pkg/compiler/rego/rego_test.go
@@ -1,0 +1,129 @@
+package compiler_rego
+
+import (
+	"testing"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/compiler/error"
+	"github.com/infobloxopen/seal/pkg/token"
+)
+
+func TestCompile(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      string
+		pols     *ast.Policies
+		expected string
+		err      error
+	}{
+		{
+			name: "validate error for empty policy",
+			err:  compiler_error.ErrEmptyPolicies,
+		},
+		{
+			name: "validate error for empty subject",
+			pkg:  "foo",
+			err:  compiler_error.ErrEmptySubject,
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: "IDENT", Literal: "allow"},
+					},
+				},
+			},
+		},
+		{
+			name: "validate error for empty verb",
+			pkg:  "foo",
+			err:  compiler_error.ErrEmptyVerb,
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: "IDENT", Literal: "allow"},
+						Action: &ast.Identifier{
+							Token: token.Token{Type: "IDENT", Literal: "allow"},
+							Value: "allow",
+						},
+						Subject: &ast.SubjectGroup{Token: "subject", Group: "foo"},
+					},
+				},
+			},
+		},
+		{
+			name: "validate error for empty type-pattern",
+			pkg:  "foo",
+			err:  compiler_error.ErrEmptyTypePattern,
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: "IDENT", Literal: "allow"},
+						Action: &ast.Identifier{
+							Token: token.Token{Type: "IDENT", Literal: "allow"},
+							Value: "allow",
+						},
+						Subject: &ast.SubjectGroup{Token: "subject", Group: "foo"},
+						TypePattern: &ast.Identifier{
+							Token: token.Token{Type: "TYPE_PATTERN", Literal: "dns.request"},
+							Value: "dns.request",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "validate policy: allow subject group foo to resolve dns.request;",
+			pkg:  "foo",
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: "IDENT", Literal: "allow"},
+						Action: &ast.Identifier{
+							Token: token.Token{Type: "IDENT", Literal: "allow"},
+							Value: "allow",
+						},
+						Subject: &ast.SubjectGroup{Token: "subject", Group: "foo"},
+						Verb: &ast.Identifier{
+							Token: token.Token{Type: "IDENT", Literal: "resolve"},
+							Value: "resolve",
+						},
+						TypePattern: &ast.Identifier{
+							Token: token.Token{Type: "TYPE_PATTERN", Literal: "dns.request"},
+							Value: "dns.request",
+
+							// TODO: MatchedTypes optimization emit map of matched types
+						},
+					},
+				},
+			},
+			expected: `
+package foo
+allow = true {
+    ` + "`foo`" + ` in input.subject.groups
+    input.verb == ` + "`resolve`" + `
+    re_match(` + "`dns.request`" + `, input.type)
+}`,
+		},
+	}
+
+	c, err := New()
+	if err != nil {
+		t.Fatalf("did not expect error creating backend - error: %s", err)
+	}
+	for idx, tst := range tests {
+		actual, err := c.Compile(tst.pkg, tst.pols)
+		if tst.err == nil && err != nil || tst.err != nil && err == nil {
+			t.Fatalf("expected error state not returned for tst #%d tst:%s.\n  expected: %s  actual: %s",
+				idx+1, tst.name, tst.err, err)
+		}
+
+		if tst.expected != actual {
+			t.Fatalf("expected output not returned for tst #%d %s.\n  EXPECTED: %s\n  ACTUAL: %s\n",
+				idx, tst.name, tst.expected, actual)
+		}
+
+		if len(tst.expected) > 0 {
+			t.Logf("%s", tst.name)
+			t.Logf("%s language output generated:\n%s", Language, tst.expected)
+		}
+	}
+}

--- a/pkg/compiler/test/compiler_test.go
+++ b/pkg/compiler/test/compiler_test.go
@@ -1,0 +1,87 @@
+package compiler_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/compiler"
+	"github.com/infobloxopen/seal/pkg/compiler/error"
+	"github.com/infobloxopen/seal/pkg/compiler/rego"
+)
+
+func TestCompiler(t *testing.T) {
+	tests := []struct {
+		name     string
+		language string
+		pkg      string
+		pols     *ast.Policies
+		expected string
+		err1     error
+		err2     error
+	}{
+		{
+			name: "validate constructor requires non-empty language",
+			err1: compiler_error.ErrEmptyLanguage,
+		},
+		{
+			name:     "validate constructor fails on unregistered language",
+			language: "doesnotexist",
+			err1:     fmt.Errorf("invalid compiler language: doesnotexist"),
+		},
+		{
+			name:     "validate compiler is constructed",
+			language: compiler_rego.Language,
+			err2:     compiler_error.ErrEmptyPolicies,
+		},
+	}
+
+	for idx, tst := range tests {
+		c, err := compiler.New(tst.language)
+		if tst.err1 == nil && err != nil || tst.err1 != nil && err == nil {
+			t.Fatalf("did not expect error creating backend for ts #%d tst:%s.\n  expected: '%s'  actual: '%s'",
+				idx+1, tst.name, tst.err1, err)
+		}
+		if err != nil {
+			continue
+		}
+
+		actual, err := c.Compile(tst.pkg, tst.pols)
+		if tst.err2 == nil && err != nil || tst.err2 != nil && err == nil {
+			t.Fatalf("expected error state not returned for tst #%d tst:%s.\n  expected: %s  actual: %s",
+				idx+1, tst.name, tst.err2, err)
+		}
+
+		if tst.expected != actual {
+			t.Fatalf("expected output not returned for tst #%d %s.\n  EXPECTED: %s\n  ACTUAL: %s\n",
+				idx, tst.name, tst.expected, actual)
+		}
+	}
+}
+
+func TestLanguages(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+	}{
+		{
+			name: "validate list of languages",
+			expected: []string{
+				compiler_rego.Language,
+			},
+		},
+	}
+
+	for idx, tst := range tests {
+		actual := compiler.Languages()
+		if !reflect.DeepEqual(tst.expected, actual) {
+			t.Fatalf("expected output not returned for tst #%d %s.\nEXPECTED: %#v\n  ACTUAL: %#v\n",
+				idx, tst.name, tst.expected, actual)
+		}
+
+		if len(tst.expected) > 0 {
+			t.Logf("%s - supported languages: %#v", tst.name, tst.expected)
+		}
+	}
+}


### PR DESCRIPTION
### DEMO1 - unit tests pass for pkt/compiler/test - shows supported languages: 
```
~/src/github.com/infobloxopen/seal/pkg/compiler/test
# wlu@wlu-mbp: go test -v
=== RUN   TestCompiler
--- PASS: TestCompiler (0.00s)
=== RUN   TestLanguages
    TestLanguages: compiler_test.go:84: validate list of languages - supported languages: []string{"rego"}
--- PASS: TestLanguages (0.00s)
PASS
ok  	github.com/infobloxopen/seal/pkg/compiler/test	0.293s
```

### DEMO2 - unit tests pass for pkt/compiler/rego - shows output sample rego generated from input policies: 
```
~/src/github.com/infobloxopen/seal/pkg/compiler/rego
# wlu@wlu-mbp: go test -v
=== RUN   TestCompile
    TestCompile: rego_test.go:125: validate policy: allow subject group foo to resolve dns.request;
    TestCompile: rego_test.go:126: rego language output generated:
        
        package foo
        allow = true {
            `foo` in input.subject.groups
            input.verb == `resolve`
            re_match(`dns.request`, input.type)
        }
--- PASS: TestCompile (0.00s)
PASS
ok  	github.com/infobloxopen/seal/pkg/compiler/rego	0.104s

```