### PR TITLE
allow email for subject user

### DIFF
--- a/docs/source/examples/simple/products.inventory.opa
+++ b/docs/source/examples/simple/products.inventory.opa
@@ -16,7 +16,7 @@ allow = true {
     re_match(`products.inventory`, input.type)
 }
 allow = true {
-    input.subject.user == `cto`
+    input.subject.user == `cto@acme.com`
     input.verb == `manage`
     re_match(`products.inventory`, input.type)
 }

--- a/docs/source/examples/simple/products.inventory.seal
+++ b/docs/source/examples/simple/products.inventory.seal
@@ -1,4 +1,4 @@
 allow subject group everyone to inspect products.inventory;
 allow subject group operators to use products.inventory;
 allow subject group admins to manage products.inventory;
-allow subject user cto to manage products.inventory;
+allow subject user cto@acme.com to manage products.inventory;

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1,7 +1,7 @@
 package lexer
 
 import (
-	"strings"
+	"regexp"
 
 	"github.com/infobloxopen/seal/pkg/token"
 )
@@ -70,14 +70,15 @@ func (l *Lexer) readIdentifier() string {
 }
 
 func isIdentifierChar(ch byte) bool {
-	return isLetter(ch) || ch == '.' || ch == '*'
+	return isLetter(ch) || ch == '.' || ch == '*' || ch == '@'
 }
 
 func isTypePattern(s string) bool {
 	if !isLetter(s[0]) {
 		return false
 	}
-	return strings.Contains(s, ".")
+	return typePatternRegex.MatchString(s)
+
 }
 
 func isLetter(ch byte) bool {
@@ -90,3 +91,7 @@ func newToken(tokenType token.TokenType, ch byte) token.Token {
 		Literal: string(ch),
 	}
 }
+
+var (
+	typePatternRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*\.([a-zA-Z_][a-zA-Z0-9_]*|[*]+)$`)
+)

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -10,7 +10,7 @@ func TestNextToken(t *testing.T) {
 
 	input := `
 	allow subject group foo to manage ddi.*;
-	allow subject user cto to manage products.*;
+	allow subject user cto@acme.com to manage products.inventory;
 	`
 
 	tests := []struct {
@@ -29,10 +29,10 @@ func TestNextToken(t *testing.T) {
 		{token.IDENT, "allow"},
 		{token.SUBJECT, "subject"},
 		{token.USER, "user"},
-		{token.IDENT, "cto"},
+		{token.IDENT, "cto@acme.com"},
 		{token.TO, "to"},
 		{token.IDENT, "manage"},
-		{token.TYPE_PATTERN, "products.*"},
+		{token.TYPE_PATTERN, "products.inventory"},
 		{token.DELIMETER, ";"},
 	}
 


### PR DESCRIPTION
### DEMO:
```
# wlu@rm-ml-wlu: make
go build

# wlu@rm-ml-wlu: ./seal compile -f docs/source/examples/simple/products.inventory.seal -o /tmp/a

# wlu@rm-ml-wlu: diff /tmp/a docs/source/examples/simple/products.inventory.opa

# wlu@rm-ml-wlu: cat docs/source/examples/simple/products.inventory.seal
allow subject group everyone to inspect products.inventory;
allow subject group operators to use products.inventory;
allow subject group admins to manage products.inventory;
allow subject user cto@acme.com to manage products.inventory;
```