### PR TITLE
GH-53: use # through end of line as comments in seal policy

### DIFF
--- a/docs/source/examples/simple/products.inventory.opa
+++ b/docs/source/examples/simple/products.inventory.opa
@@ -1,14 +1,11 @@
 
 package products.inventory.seal
 allow = true {
-    `everyone` in input.subject.groups
-    input.verb == `inspect`
-    re_match(`products.inventory`, input.type)
-}
-allow = true {
     `operators` in input.subject.groups
     input.verb == `use`
     re_match(`products.inventory`, input.type)
+} where {
+    ctx.id = "bar" and ctx.name = "foo"
 }
 allow = true {
     `admins` in input.subject.groups

--- a/docs/source/examples/simple/products.inventory.seal
+++ b/docs/source/examples/simple/products.inventory.seal
@@ -1,3 +1,4 @@
 allow subject group operators to use products.inventory where ctx.id == "bar" and ctx.name=="foo";
 allow subject group admins to manage products.inventory;
 allow subject user cto@acme.com to manage products.inventory;
+# this is a comment

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -91,6 +91,7 @@ components:
 			policyString: `
 				allow subject group everyone to inspect products.inventory where ctx.id=="bar";
 				allow subject group nobody to use products.inventory;
+				# WIP
 				`,
 			result: `
 				package products.inventory

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -41,6 +41,11 @@ func (l *Lexer) NextToken() token.Token {
 	l.skipWhitespace()
 
 	switch l.ch {
+	case '#':
+		tok = newToken(token.DELIMETER, l.ch)
+		tok.Literal = l.readComment()
+		tok.Type = token.COMMENT
+		return tok
 	case ';':
 		tok = newToken(token.DELIMETER, l.ch)
 	case '(':
@@ -90,6 +95,19 @@ func (l *Lexer) readLiteral() string {
 	return l.input[start:l.position]
 }
 
+func (l *Lexer) readComment() string {
+	l.readChar()
+	start := l.position
+	for !isNewline(l.ch) {
+		l.readChar()
+	}
+	end := l.position
+	if '\r' == l.input[end-1] {
+		end -= 1
+	}
+	return l.input[start:end]
+}
+
 func isIdentifierChar(ch byte) bool {
 	return isLetter(ch) || ch == '.' || ch == '*' || ch == '@'
 }
@@ -124,6 +142,10 @@ func isLetter(ch byte) bool {
 
 func isNumber(ch byte) bool {
 	return '0' <= ch && ch <= '9'
+}
+
+func isNewline(ch byte) bool {
+	return '\n' == ch
 }
 
 func newToken(tokenType token.TokenType, ch byte) token.Token {

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -9,9 +9,10 @@ import (
 func TestNextToken(t *testing.T) {
 
 	input := `
-	allow subject group foo to manage ddi.*;
-	allow subject user cto@acme.com to manage products.inventory;
-	allow subject user cto@acme.com to manage products.inventory where ctx.tag["foo"] == "bar";
+	allow subject group managers to manage petstore.*;
+	allow subject user cto@petstore.swagger.io to manage petstore.*;
+	allow subject group customers to buy petstore.pet where ctx.tag["color"] == "purple";
+	allow subject group everyone to read petstore.pet;
 	`
 
 	tests := []struct {
@@ -21,33 +22,42 @@ func TestNextToken(t *testing.T) {
 		{token.IDENT, "allow"},
 		{token.SUBJECT, "subject"},
 		{token.GROUP, "group"},
-		{token.IDENT, "foo"},
+		{token.IDENT, "managers"},
 		{token.TO, "to"},
 		{token.IDENT, "manage"},
-		{token.TYPE_PATTERN, "ddi.*"},
+		{token.TYPE_PATTERN, "petstore.*"},
 		{token.DELIMETER, ";"},
 
 		{token.IDENT, "allow"},
 		{token.SUBJECT, "subject"},
 		{token.USER, "user"},
-		{token.IDENT, "cto@acme.com"},
+		{token.IDENT, "cto@petstore.swagger.io"},
 		{token.TO, "to"},
 		{token.IDENT, "manage"},
-		{token.TYPE_PATTERN, "products.inventory"},
+		{token.TYPE_PATTERN, "petstore.*"},
 		{token.DELIMETER, ";"},
 
 		{token.IDENT, "allow"},
 		{token.SUBJECT, "subject"},
-		{token.USER, "user"},
-		{token.IDENT, "cto@acme.com"},
+		{token.GROUP, "group"},
+		{token.IDENT, "customers"},
 		{token.TO, "to"},
-		{token.IDENT, "manage"},
-		{token.TYPE_PATTERN, "products.inventory"},
+		{token.IDENT, "buy"},
+		{token.TYPE_PATTERN, "petstore.pet"},
 		{token.WHERE, "where"},
 		{token.TYPE_PATTERN, "ctx.tag"},
-		{token.LITERAL, "foo"},
+		{token.LITERAL, "color"},
 		{token.OP_COMPARISON, "=="},
-		{token.LITERAL, "bar"},
+		{token.LITERAL, "purple"},
+		{token.DELIMETER, ";"},
+
+		{token.IDENT, "allow"},
+		{token.SUBJECT, "subject"},
+		{token.GROUP, "group"},
+		{token.IDENT, "everyone"},
+		{token.TO, "to"},
+		{token.IDENT, "read"},
+		{token.TYPE_PATTERN, "petstore.pet"},
 		{token.DELIMETER, ";"},
 	}
 
@@ -56,13 +66,144 @@ func TestNextToken(t *testing.T) {
 		tok := l.NextToken()
 
 		if tok.Type != tt.expectedType {
-			t.Fatalf("tests[%d] %q - tokentype wrong. expected=%q, got %q",
-				i, tt.expectedLiteral, tt.expectedType, tok.Type)
+			t.Fatalf("tests[%d] %q - tokentype wrong. expected=%q, got %#v",
+				i, tt.expectedLiteral, tt.expectedType, tok)
 		}
 
 		if tok.Literal != tt.expectedLiteral {
 			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
 				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+func TestNextTokenComment(t *testing.T) {
+
+	type expected struct {
+		typ     token.TokenType
+		literal string
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected []expected
+	}{
+		{
+			name: "first comment",
+			input: `
+	# this is the first comment
+	allow subject group managers to manage petstore.*;
+	`,
+			expected: []expected{
+				{token.COMMENT, " this is the first comment"},
+
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "managers"},
+				{token.TO, "to"},
+				{token.IDENT, "manage"},
+				{token.TYPE_PATTERN, "petstore.*"},
+				{token.DELIMETER, ";"},
+			},
+		},
+		{
+			name: "infix comment",
+			input: `
+	allow subject group managers to manage petstore.*;
+	# this is another comment
+	allow subject group everyone to read petstore.pet;
+	`,
+			expected: []expected{
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "managers"},
+				{token.TO, "to"},
+				{token.IDENT, "manage"},
+				{token.TYPE_PATTERN, "petstore.*"},
+				{token.DELIMETER, ";"},
+
+				{token.COMMENT, " this is another comment"},
+
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "everyone"},
+				{token.TO, "to"},
+				{token.IDENT, "read"},
+				{token.TYPE_PATTERN, "petstore.pet"},
+				{token.DELIMETER, ";"},
+			},
+		},
+		{
+			name: "end comment",
+			input: `
+	allow subject group everyone to read petstore.pet;
+	# this is the last comment
+	`,
+			expected: []expected{
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "everyone"},
+				{token.TO, "to"},
+				{token.IDENT, "read"},
+				{token.TYPE_PATTERN, "petstore.pet"},
+				{token.DELIMETER, ";"},
+
+				{token.COMMENT, " this is the last comment"},
+			},
+		},
+		{
+			name: "carriage returns",
+			input: `
+	# comment with carriage return` + "\r" + `
+	allow subject group managers to manage petstore.*;` + "\n" +
+				"#\r\n" +
+	"allow subject group everyone to read petstore.pet;",
+			expected: []expected{
+				{token.COMMENT, " comment with carriage return"},
+
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "managers"},
+				{token.TO, "to"},
+				{token.IDENT, "manage"},
+				{token.TYPE_PATTERN, "petstore.*"},
+				{token.DELIMETER, ";"},
+
+				{token.COMMENT, ""},
+
+				{token.IDENT, "allow"},
+				{token.SUBJECT, "subject"},
+				{token.GROUP, "group"},
+				{token.IDENT, "everyone"},
+				{token.TO, "to"},
+				{token.IDENT, "read"},
+				{token.TYPE_PATTERN, "petstore.pet"},
+				{token.DELIMETER, ";"},
+
+			},
+		},
+	}
+
+	for _, tst := range tests {
+		l := New(tst.input)
+		for i, tt := range tst.expected {
+			tok := l.NextToken()
+
+			if tok.Type != tt.typ {
+				t.Fatalf("tests[%q][%d] %q - tokentype wrong. expected=%q, got %#v",
+					tst.name, i, tt.literal, tt.typ, tok)
+			}
+
+			if tok.Literal != tt.literal {
+				t.Fatalf("tests[%q][%d] - literal wrong. expected=%q, got=%q",
+					tst.name, i, tt.literal, tok.Literal)
+			}
 		}
 	}
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -12,6 +12,7 @@ const (
 	EOF     = "EOF"
 	LITERAL = "LITERAL"
 
+	COMMENT       = "#"
 	IDENT         = "IDENT"
 	TYPE_PATTERN  = "TYPE_PATTERN"
 	DELIMETER     = ";"


### PR DESCRIPTION
example of policy with a comment:
```
...
allow subject user cto@acme.com to manage products.inventory;
# this is a comment
```