### PR TITLE
GH-57: rego compiler generates valid rego for simple where clause

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -40,6 +40,13 @@ allow {
 	re_match(`petstore.pet`, input.type)
 }
 
+allow {
+	seal_list_contains(input.subject.groups, `customers`)
+	input.verb == `buy`
+	re_match(`petstore.pet`, input.type)
+	input.status == "available"
+}
+
 # rego functions defined by seal
 
 # seal_list_contains returns true if elem exists in list

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -12,6 +12,8 @@ allow subject user cto@petstore.swagger.io to manage petstore.*;
 allow subject group everyone to inspect petstore.pet;
 allow subject group customers to read petstore.pet;
 
+allow subject group customers to buy petstore.pet where ctx.status == "available";
+
 # ==== WIP:
 #allow subject group everyone to manage petstore.order where ctx.buyer.email == subject.email;
 #

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -15,13 +15,14 @@ func checkError(t *testing.T, got, expected error) bool {
 	}
 	if (got != nil) && (expected != nil) {
 		if got.Error() != expected.Error() {
-			t.Fatalf("\nexpected =\t'%+v'\ngot =\t'%+v'", expected, got)
+			t.Fatalf("\nexpected = '%+v'\ngot =      '%+v'", expected, got)
 		} else {
 			return true
 		}
 	}
 	return false
 }
+
 func TestBackend(gt *testing.T) {
 	swaggerContent := strings.ReplaceAll(`openapi: "3.0.0"
 components:
@@ -79,12 +80,60 @@ components:
 			swaggerContent: "openapi: \"3.0.0\"\ncomponents:\n  schemas:",
 			swaggerError:   errors.New("Swagger error: no actions are defined"),
 		},
-		"policies errors": {
-			packageName: "products.errors",
-			policyString: `
-				allow subject group everyone to inspect fake;
-				`,
-			compilerError: errors.New("expected next token to be TYPE_PATTERN, got IDENT instead\nexpected next token to be user or group, got IDENT instead"),
+		"missing to errors": {
+			packageName:   "products.errors",
+			policyString:  `allow;`,
+			compilerError: errors.New("expected next token to be to, got ; instead"),
+		},
+		"missing verb errors": {
+			packageName:   "products.errors",
+			policyString:  `allow to;`,
+			compilerError: errors.New("expected next token to be IDENT, got ; instead"),
+		},
+		"missing resource errors": {
+			packageName:   "products.errors",
+			policyString:  `allow to inspect;`,
+			compilerError: errors.New("expected next token to be TYPE_PATTERN, got ; instead"),
+		},
+		"invalid resource format without using family.type errors": {
+			packageName:  "products.errors",
+			policyString: `allow to inspect fake;`,
+			compilerError: errors.New(
+				`expected next token to be TYPE_PATTERN, got IDENT instead
+expected next token to be to, got ; instead`),
+		},
+		"invalid resource not registered": {
+			packageName:   "products.errors",
+			policyString:  `allow to inspect fake.fake;`,
+			compilerError: errors.New(`type pattern fake.fake did not match any registered types`),
+		},
+		/* TODO: subject should be optional and not required
+		"simplest statement": {
+			packageName: "products.inventory",
+			policyString: `allow to inspect products.inventory;`,
+			result: `TODO`,
+		},
+		*/
+		"simplest statement with subject": {
+			packageName:  "products.inventory",
+			policyString: `allow subject group everyone to inspect products.inventory;`,
+			result: `
+package products.inventory
+default allow = false
+default deny = false
+allow {
+    seal_list_contains(input.subject.groups, 'everyone')
+    input.verb == 'inspect'
+    re_match('products.inventory', input.type)
+}
+
+# rego functions defined by seal
+
+# seal_list_contains returns true if elem exists in list
+seal_list_contains(list, elem) {
+    list[_] = elem
+}
+`,
 		},
 		"products.inventory": {
 			packageName: "products.inventory",
@@ -94,61 +143,62 @@ components:
 				# WIP
 				`,
 			result: `
-				package products.inventory
-				default allow = false
-				default deny = false
-				allow {
-					seal_list_contains(input.subject.groups, 'everyone')
-					input.verb == 'inspect'
-					re_match('products.inventory', input.type)
-				} where ctx.id = "bar"
-				allow {
-					seal_list_contains(input.subject.groups, 'nobody')
-					input.verb == 'use'
-					re_match('products.inventory', input.type)
-				}
+package products.inventory
+default allow = false
+default deny = false
+allow {
+    seal_list_contains(input.subject.groups, 'everyone')
+    input.verb == 'inspect'
+    re_match('products.inventory', input.type)
+    input.id == "bar"
+}
+allow {
+    seal_list_contains(input.subject.groups, 'nobody')
+    input.verb == 'use'
+    re_match('products.inventory', input.type)
+}
 
-				# rego functions defined by seal
+# rego functions defined by seal
 
-				# seal_list_contains returns true if elem exists in list
-				seal_list_contains(list, elem) {
-					list[_] = elem
-				}
+# seal_list_contains returns true if elem exists in list
+seal_list_contains(list, elem) {
+    list[_] = elem
+}
 `,
 		},
-		"products.inventory.2": {
-			packageName: "products.inventory",
-			policyString: `
-				allow subject group everyone to inspect products.inventory where ctx.id=="bar" and (ctx.name=="foo" or ctx.name=="bar2");
-				allow subject group nobody to use products.inventory;
-				`,
-			result: `
-				package products.inventory
-				default allow = false
-				default deny = false
-				allow {
-					seal_list_contains(input.subject.groups, 'everyone')
-					input.verb == 'inspect'
-					re_match('products.inventory', input.type)
-				} where {
-					ctx.id = "bar" and {
-					ctx.name = "foo" or ctx.name = "bar2"
-				}
-				}
-				allow {
-					seal_list_contains(input.subject.groups, 'nobody')
-					input.verb == 'use'
-					re_match('products.inventory', input.type)
-				}
+		/* TODO: where clause with and does not currently work
+		   		"products.inventory.2": {
+		   			packageName: "products.inventory",
+		   			policyString: `
+		   				allow subject group everyone to inspect products.inventory where ctx.id=="bar" and ctx.name=="foo";
+		   				allow subject group nobody to use products.inventory;
+		   				`,
+		   			result: `
+		   				package products.inventory
+		   				default allow = false
+		   				default deny = false
+		   				allow {
+		   					seal_list_contains(input.subject.groups, 'everyone')
+		   					input.verb == 'inspect'
+		   					re_match('products.inventory', input.type)
+		   					ctx.id = "bar"
+		   					ctx.name = "foo"
+		   				}
+		   				allow {
+		   					seal_list_contains(input.subject.groups, 'nobody')
+		   					input.verb == 'use'
+		   					re_match('products.inventory', input.type)
+		   				}
 
-				# rego functions defined by seal
+		   				# rego functions defined by seal
 
-				# seal_list_contains returns true if elem exists in list
-				seal_list_contains(list, elem) {
-					list[_] = elem
-				}
-`,
-		},
+		   				# seal_list_contains returns true if elem exists in list
+		   				seal_list_contains(list, elem) {
+		   					list[_] = elem
+		   				}
+		   `,
+		   		},
+		*/
 		"company.personnel": {
 			packageName:  "company.personnel",
 			policyString: "allow subject group manager to operate company.*;\nallow subject group users to list company.personnel;",
@@ -191,17 +241,17 @@ components:
 				swContent = tCase.swaggerContent
 			}
 			cmplr, err = compiler.NewPolicyCompiler(compiler_rego.Language, strings.Trim(swContent, " "))
-			if checkError(t, err, tCase.swaggerError) == true {
+			if checkError(t, err, tCase.swaggerError) {
 				return
 			}
 
 			result, err := cmplr.Compile(tCase.packageName, tCase.policyString)
-			if checkError(t, err, tCase.compilerError) == true {
+			if checkError(t, err, tCase.compilerError) {
 				return
 			}
 
 			if strings.Compare(result, tCase.result) != 0 {
-				t.Errorf("Unexpected result\nexpected =\t'%+v'\ngot =\t'%+v'", tCase.result, result)
+				t.Errorf("Unexpected result\nexpected = '%+v'\ngot =         '%+v'", tCase.result, result)
 			}
 		})
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -82,11 +82,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	}
 }
 
+// parseSubject parses the subject clause `subject { group | user } X`
 func (p *Parser) parseSubject() ast.Subject {
-
-	// This function parses the subject clause
-	// `subject group X to`
-
 	t := p.curToken
 	p.nextToken()
 
@@ -111,12 +108,8 @@ func (p *Parser) parseSubject() ast.Subject {
 			User:  p.curToken.Literal,
 		}
 	default:
-		msg := fmt.Sprintf("expected next token to be user or group, got %s instead",
-			p.curToken.Type)
+		msg := fmt.Sprintf("expected next token to be user or group, got %s instead", p.curToken.Type)
 		p.errors = append(p.errors, msg)
-		return nil
-	}
-	if !p.expectPeek(token.TO) {
 		return nil
 	}
 	return subject
@@ -171,42 +164,31 @@ func (p *Parser) parseActionStatement() (stmt *ast.ActionStatement) {
 		Token: p.curToken,
 	}
 
+	// action is required
 	stmt.Action = &ast.Identifier{
 		Token: p.curToken,
 		Value: p.curToken.Literal,
 	}
 
+	// subject is optional
 	if p.peekToken.Type == token.SUBJECT {
 		p.nextToken()
 		stmt.Subject = p.parseSubject()
 	}
 
-	switch p.peekToken.Type {
-	case token.IDENT:
-		if !p.expectPeek(token.IDENT) {
-			return nil
-		}
-
-		stmt.Verb = &ast.Identifier{
-			Token: p.curToken,
-			Value: p.curToken.Literal,
-		}
-	case token.TYPE_PATTERN:
-		if !p.expectPeek(token.TYPE_PATTERN) {
-			return nil
-		}
-		stmt.TypePattern = &ast.Identifier{
-			Token: p.curToken,
-			Value: p.curToken.Literal,
-		}
-		return stmt
-	default:
-		msg := fmt.Sprintf("expected next token to be user or group, got %s instead",
-			p.curToken.Type)
-		p.errors = append(p.errors, msg)
+	// verb is required
+	if !p.expectPeek(token.TO) { //  is required
 		return nil
 	}
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+	stmt.Verb = &ast.Identifier{
+		Token: p.curToken,
+		Value: p.curToken.Literal,
+	}
 
+	// resource is required
 	if !p.expectPeek(token.TYPE_PATTERN) {
 		return nil
 	}
@@ -215,6 +197,7 @@ func (p *Parser) parseActionStatement() (stmt *ast.ActionStatement) {
 		Value: p.curToken.Literal,
 	}
 
+	// where clause is optional
 	if p.peekToken.Type == token.WHERE {
 		p.nextToken()
 		stmt.WhereClause = p.parseWhereClause()


### PR DESCRIPTION
### DEMO - simplest where clause works now:
`allow subject group customers to buy petstore.pet where ctx.status == "available";` 

```
# wlu@rm-ml-wlu: make demo
./seal compile -s docs/source/examples/petstore/petstore.all.swagger -f docs/source/examples/petstore/petstore.all.seal | tee docs/source/examples/petstore/petstore.all.rego

...

allow {
    seal_list_contains(input.subject.groups, `customers`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
    input.status == "available"
}

...

gidata.petstore.all.test_banned_deny: PASS (459.4µs)
data.petstore.all.test_banned_deny_negative: PASS (217.1µs)
data.petstore.all.test_inspect: PASS (290.9µs)
data.petstore.all.test_inspect_negative: PASS (222.7µs)
data.petstore.all.test_read: PASS (257µs)
data.petstore.all.test_read_negative: PASS (318µs)
data.petstore.all.test_manage_cto: PASS (314.3µs)
--------------------------------------------------------------------------------
PASS: 7/7
...
### petstore example passed REGO OPA tests

```