### PR TITLE
GH-44: fixed lexer comparison operators; added simple where clause not equal operator demo

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -10,6 +10,13 @@ deny {
 	re_match(`petstore.*`, input.type)
 }
 
+deny {
+	seal_list_contains(input.subject.groups, `managers`)
+	input.verb == `sell`
+	re_match(`petstore.pet`, input.type)
+	input.status != "available"
+}
+
 allow {
 	seal_list_contains(input.subject.groups, `operators`)
 	input.verb == `use`

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,4 +1,6 @@
 deny subject group banned to manage petstore.*;
+deny subject group managers to sell petstore.pet where ctx.status != "available";
+
 # ==== WIP:
 #deny (notify="true") subject group everyone to provision petstore.pet
 #    where ctx.pet.category.name in $company.list["name=endangered"];

--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -47,6 +47,9 @@ components:
       - read
       - use
       - manage
+      - approve
+      - ship
+      - deliver
       x-seal-default-action: deny
     petstore.pet:
       type: object
@@ -60,6 +63,7 @@ components:
       - manage
       - provision
       - buy
+      - sell
       x-seal-default-action: deny
       properties:
         id:
@@ -73,6 +77,7 @@ components:
           enum:
           - "available"
           - "pending"
+          - "reserved"
           - "sold"
         category:
           $ref: "#/components/schemas/category"

--- a/pkg/compiler/rego/rego.go
+++ b/pkg/compiler/rego/rego.go
@@ -176,7 +176,7 @@ func (c *CompilerRego) compileConditions(o ast.Conditions, lvl int) (string, err
 		if s.Operator != nil {
 			return fmt.Sprintf("    %s[\"%s\"] = \"%s\"", lhs, s.Operator.Value, rhs), nil
 		}
-		return fmt.Sprintf("    %s == \"%s\"", lhs, rhs), nil
+		return fmt.Sprintf("    %s %s \"%s\"", lhs, s.Token.Literal, rhs), nil
 	case *ast.BinaryCondition:
 		LHS, err := c.compileConditions(s.LHS, lvl+1)
 		if err != nil {

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -139,6 +139,7 @@ seal_list_contains(list, elem) {
 			packageName: "products.inventory",
 			policyString: `
 				allow subject group everyone to inspect products.inventory where ctx.id=="bar";
+				allow subject group everyone to inspect products.inventory where ctx.id!="bar";
 				allow subject group nobody to use products.inventory;
 				# WIP
 				`,
@@ -151,6 +152,12 @@ allow {
     input.verb == 'inspect'
     re_match('products.inventory', input.type)
     input.id == "bar"
+}
+allow {
+    seal_list_contains(input.subject.groups, 'everyone')
+    input.verb == 'inspect'
+    re_match('products.inventory', input.type)
+    input.id != "bar"
 }
 allow {
     seal_list_contains(input.subject.groups, 'nobody')

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -67,9 +67,9 @@ func (l *Lexer) NextToken() token.Token {
 			}
 			return tok
 		}
-		if isSign(l.ch) {
-			tok.Literal = l.readSign()
-			tok.Type = token.LookupIdent(tok.Literal)
+		if isOperator(l.ch) {
+			tok.Literal = l.readOperator()
+			tok.Type = token.LookupOperator(tok.Literal)
 			return tok
 		}
 		tok = newToken(token.ILLEGAL, l.ch)
@@ -116,13 +116,13 @@ func isLiteralChar(ch byte) bool {
 	return isLetter(ch) || isNumber(ch)
 }
 
-func isSign(ch byte) bool {
-	return ch == '=' || ch == '!' || ch == '>' || ch == '<' || ch == '~'
+func isOperator(ch byte) bool {
+	return ch == '=' || ch == '!' || ch == '<' || ch == '>'
 }
 
-func (l *Lexer) readSign() string {
+func (l *Lexer) readOperator() string {
 	start := l.position
-	for isSign(l.ch) {
+	for isOperator(l.ch) {
 		l.readChar()
 	}
 	return l.input[start:l.position]

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -13,6 +13,7 @@ func TestNextToken(t *testing.T) {
 	allow subject user cto@petstore.swagger.io to manage petstore.*;
 	allow subject group customers to buy petstore.pet where ctx.tag["color"] == "purple";
 	allow subject group everyone to read petstore.pet;
+	=== !! << >> == != < > <= >=
 	`
 
 	tests := []struct {
@@ -47,7 +48,7 @@ func TestNextToken(t *testing.T) {
 		{token.WHERE, "where"},
 		{token.TYPE_PATTERN, "ctx.tag"},
 		{token.LITERAL, "color"},
-		{token.OP_COMPARISON, "=="},
+		{token.OP_EQUAL_TO, "=="},
 		{token.LITERAL, "purple"},
 		{token.DELIMETER, ";"},
 
@@ -59,6 +60,17 @@ func TestNextToken(t *testing.T) {
 		{token.IDENT, "read"},
 		{token.TYPE_PATTERN, "petstore.pet"},
 		{token.DELIMETER, ";"},
+
+		{token.ILLEGAL, "==="},
+		{token.ILLEGAL, "!!"},
+		{token.ILLEGAL, "<<"},
+		{token.ILLEGAL, ">>"},
+		{token.OP_EQUAL_TO, "=="},
+		{token.OP_NOT_EQUAL, "!="},
+		{token.OP_LESS_THAN, "<"},
+		{token.OP_GREATER_THAN, ">"},
+		{token.OP_LESS_EQUAL, "<="},
+		{token.OP_GREATER_EQUAL, ">="},
 	}
 
 	l := New(input)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -296,9 +296,12 @@ func (p *Parser) parseUnaryConditions() ast.Conditions {
 		}
 	}
 
-	if !p.expectPeek(token.OP_COMPARISON) {
+	if token.LookupOperatorComparison(p.peekToken.Literal) == token.ILLEGAL {
+		msg := fmt.Sprintf("expected next token to be comparison operator, got %s instead", p.peekToken.Type)
+		p.errors = append(p.errors, msg)
 		return nil
 	}
+	p.nextToken()
 	op.Token = p.curToken
 
 	if !p.expectPeek(token.LITERAL) {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -12,13 +12,18 @@ const (
 	EOF     = "EOF"
 	LITERAL = "LITERAL"
 
-	COMMENT       = "#"
-	IDENT         = "IDENT"
-	TYPE_PATTERN  = "TYPE_PATTERN"
-	DELIMETER     = ";"
-	OP_COMPARISON = "=="
-	OPEN_PAREN    = "("
-	CLOSE_PAREN   = ")"
+	COMMENT          = "#"
+	IDENT            = "IDENT"
+	TYPE_PATTERN     = "TYPE_PATTERN"
+	DELIMETER        = ";"
+	OP_EQUAL_TO      = "=="
+	OP_NOT_EQUAL     = "!="
+	OP_LESS_THAN     = "<"
+	OP_GREATER_THAN  = ">"
+	OP_LESS_EQUAL    = "<="
+	OP_GREATER_EQUAL = ">="
+	OPEN_PAREN       = "("
+	CLOSE_PAREN      = ")"
 
 	// keywords
 	WITH    = "with"
@@ -49,8 +54,25 @@ func LookupIdent(ident string) TokenType {
 	if ident == DELIMETER {
 		return DELIMETER
 	}
-	if ident == OP_COMPARISON {
-		return OP_COMPARISON
-	}
 	return IDENT
+}
+
+func LookupOperatorComparison(op string) TokenType {
+	switch op {
+	default:
+		return ILLEGAL
+
+	case OP_EQUAL_TO:
+	case OP_NOT_EQUAL:
+	case OP_LESS_THAN:
+	case OP_GREATER_THAN:
+	case OP_LESS_EQUAL:
+	case OP_GREATER_EQUAL:
+	}
+
+	return TokenType(op)
+}
+
+func LookupOperator(op string) TokenType {
+	return LookupOperatorComparison(op)
 }


### PR DESCRIPTION
### DEMO:
`deny subject group managers to sell petstore.pet where ctx.status != "available";`

```
# wlu@rm-ml-wlu: make demo
./seal compile -s docs/source/examples/petstore/petstore.all.swagger -f docs/source/examples/petstore/petstore.all.seal | tee docs/source/examples/petstore/petstore.all.rego

...
deny {
    seal_list_contains(input.subject.groups, `managers`)
    input.verb == `sell`
    re_match(`petstore.pet`, input.type)
    input.status != "available"
}

...

```

one to one mapping of SEAL and OPA Comparison Operators:
https://www.openpolicyagent.org/docs/latest/policy-language/#comparison-operators
```
a  ==  b  #  `a` is equal to `b`.
a  !=  b  #  `a` is not equal to `b`.
a  <   b  #  `a` is less than `b`.
a  <=  b  #  `a` is less than or equal to `b`.
a  >   b  #  `a` is greater than `b`.
a  >=  b  #  `a` is greater than or equal to `b`.
```
https://www.openpolicyagent.org/docs/latest/policy-language/#comparison-operators