### PR TITLE
GH-60: implemented pratt parser for conditionals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ demo: petstore
 .PHONY: petstore
 petstore: dir=docs/source/examples/petstore
 petstore: seal
-	./seal compile -s $(dir)/petstore.all.swagger -f $(dir)/petstore.all.seal | tee $(dir)/petstore.all.rego
+	./seal compile -s $(dir)/petstore.all.swagger -f $(dir)/petstore.all.seal | tee $(dir)/petstore.all.rego.compiled
+	cp $(dir)/petstore.all.rego.compiled $(dir)/petstore.all.rego
+	# beware that check-rego.sh reformats the compiled rego files...
 	./docs/source/examples/check-rego.sh $(dir)
 	git diff --exit-code $(dir)
 	@echo "### petstore example passed REGO OPA tests"

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -1,0 +1,54 @@
+
+package petstore.all
+default allow = false
+default deny = false
+deny {
+    seal_list_contains(input.subject.groups, `banned`)
+    input.verb == `manage`
+    re_match(`petstore.*`, input.type)
+}
+deny {
+    seal_list_contains(input.subject.groups, `managers`)
+    input.verb == `sell`
+    re_match(`petstore.pet`, input.type)
+(input.status != "available")
+}
+allow {
+    seal_list_contains(input.subject.groups, `operators`)
+    input.verb == `use`
+    re_match(`petstore.*`, input.type)
+}
+allow {
+    seal_list_contains(input.subject.groups, `managers`)
+    input.verb == `manage`
+    re_match(`petstore.*`, input.type)
+}
+allow {
+    input.subject.email == `cto@petstore.swagger.io`
+    input.verb == `manage`
+    re_match(`petstore.*`, input.type)
+}
+allow {
+    seal_list_contains(input.subject.groups, `everyone`)
+    input.verb == `inspect`
+    re_match(`petstore.pet`, input.type)
+}
+allow {
+    seal_list_contains(input.subject.groups, `customers`)
+    input.verb == `read`
+    re_match(`petstore.pet`, input.type)
+}
+allow {
+    seal_list_contains(input.subject.groups, `customers`)
+    input.verb == `buy`
+    re_match(`petstore.pet`, input.type)
+(input.status == "available")
+}
+
+# rego functions defined by seal
+
+# seal_list_contains returns true if elem exists in list
+seal_list_contains(list, elem) {
+    list[_] = elem
+}
+

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -151,13 +151,13 @@ allow {
     seal_list_contains(input.subject.groups, 'everyone')
     input.verb == 'inspect'
     re_match('products.inventory', input.type)
-    input.id == "bar"
+(input.id == "bar")
 }
 allow {
     seal_list_contains(input.subject.groups, 'everyone')
     input.verb == 'inspect'
     re_match('products.inventory', input.type)
-    input.id != "bar"
+(input.id != "bar")
 }
 allow {
     seal_list_contains(input.subject.groups, 'nobody')

--- a/pkg/parser/condition.go
+++ b/pkg/parser/condition.go
@@ -1,0 +1,131 @@
+package parser
+
+// parsing conditions as Pratt parser - Top Down Operator Precedence
+
+import (
+	"fmt"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/token"
+)
+
+type (
+	prefixConditionParseFn func() ast.Condition
+	infixConditionParseFn  func(ast.Condition) ast.Condition
+)
+
+func (p *Parser) registerPrefixConditionParseFns() {
+	if p.prefixConditionParseFns == nil {
+		p.prefixConditionParseFns = make(map[token.TokenType]prefixConditionParseFn)
+	}
+
+	p.registerPrefixCondition(token.TYPE_PATTERN, p.parseIdentifier)
+	p.registerPrefixCondition(token.LITERAL, p.parseIdentifier)
+}
+
+func (p *Parser) registerPrefixCondition(tokenType token.TokenType, fn prefixConditionParseFn) {
+	p.prefixConditionParseFns[tokenType] = fn
+}
+
+func (p *Parser) registerInfixConditionParseFns() {
+	if p.infixConditionParseFns == nil {
+		p.infixConditionParseFns = make(map[token.TokenType]infixConditionParseFn)
+	}
+
+	p.registerInfixCondition(token.OP_EQUAL_TO, p.parseInfixCondition)
+	p.registerInfixCondition(token.OP_NOT_EQUAL, p.parseInfixCondition)
+	p.registerInfixCondition(token.OP_LESS_THAN, p.parseInfixCondition)
+	p.registerInfixCondition(token.OP_GREATER_THAN, p.parseInfixCondition)
+	p.registerInfixCondition(token.OP_LESS_EQUAL, p.parseInfixCondition)
+	p.registerInfixCondition(token.OP_GREATER_EQUAL, p.parseInfixCondition)
+}
+
+func (p *Parser) registerInfixCondition(tokenType token.TokenType, fn infixConditionParseFn) {
+	p.infixConditionParseFns[tokenType] = fn
+}
+
+// parsers
+func (p *Parser) parseIdentifier() ast.Condition {
+	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseLiteral() ast.Condition {
+	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseWhereClause() *ast.WhereClause {
+	wc := &ast.WhereClause{Token: p.curToken}
+	p.nextToken()
+	wc.Condition = p.parseCondition(PRECEDENCE_LOWEST)
+	return wc
+}
+
+func (p *Parser) parseCondition(precedence int) ast.Condition {
+	prefix := p.prefixConditionParseFns[p.curToken.Type]
+	if prefix == nil {
+		p.noPrefixConditionParseFnError(p.curToken.Type)
+		return nil
+	}
+	leftExp := prefix()
+	for !p.peekTokenIs(token.DELIMETER) && precedence < p.peekPrecedence() {
+		infix := p.infixConditionParseFns[p.peekToken.Type]
+		if infix == nil {
+			return leftExp
+		}
+		p.nextToken()
+		leftExp = infix(leftExp)
+	}
+	return leftExp
+}
+
+func (p *Parser) noPrefixConditionParseFnError(t token.TokenType) {
+	msg := fmt.Sprintf("no prefix condition parse function for %s found", t)
+	p.errors = append(p.errors, msg)
+}
+
+func (p *Parser) parseInfixCondition(left ast.Condition) ast.Condition {
+	condition := &ast.InfixCondition{
+		Token:    p.curToken,
+		Operator: p.curToken.Literal,
+		Left:     left,
+	}
+	precedence := p.curPrecedence()
+	p.nextToken()
+	condition.Right = p.parseCondition(precedence)
+	return condition
+}
+
+// precedences
+const (
+	_ int = iota
+	PRECEDENCE_LOWEST
+	PRECEDENCE_EQUALS      // ==
+	PRECEDENCE_LESSGREATER // > or <
+	PRECEDENCE_SUM         // +
+	PRECEDENCE_PRODUCT     // *
+	PRECEDENCE_PREFIX      // -X or !X
+	PRECEDENCE_CALL        // myFunction(X)
+)
+
+var precedences = map[token.TokenType]int{
+	token.OP_EQUAL_TO:      PRECEDENCE_EQUALS,
+	token.OP_NOT_EQUAL:     PRECEDENCE_EQUALS,
+	token.OP_LESS_THAN:     PRECEDENCE_LESSGREATER,
+	token.OP_GREATER_THAN:  PRECEDENCE_LESSGREATER,
+	token.OP_LESS_EQUAL:    PRECEDENCE_LESSGREATER,
+	token.OP_GREATER_EQUAL: PRECEDENCE_LESSGREATER,
+}
+
+func (p *Parser) peekPrecedence() int {
+	if p, ok := precedences[p.peekToken.Type]; ok {
+		return p
+	}
+	return PRECEDENCE_LOWEST
+}
+
+func (p *Parser) curPrecedence() int {
+	if p, ok := precedences[p.curToken.Type]; ok {
+		return p
+	}
+	return PRECEDENCE_LOWEST
+}

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -1,0 +1,118 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/infobloxopen/seal/pkg/lexer"
+	"github.com/infobloxopen/seal/pkg/types"
+)
+
+func TestWhereClause(t *testing.T) {
+	typesContent := `
+openapi: "3.0.0"
+components:
+  schemas:
+    allow:
+      type: object
+      properties:
+        log:
+          type: boolean
+      x-seal-type: action
+    petstore.pet:
+      type: object
+      x-seal-actions:
+      - allow
+      - deny
+      x-seal-verbs:
+      - inspect
+      - read
+      - use
+      - manage
+      - buy
+      x-seal-default-action: deny
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+        is_healthy:
+          type: bool
+    iam.user:
+      type: object
+      x-seal-actions:
+      - allow
+      - deny
+      x-seal-verbs:
+      - inspect
+      - read
+      - use
+      - manage
+      - sign_in
+      x-seal-default-action: deny
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+`
+
+	testcases := []struct {
+		name     string
+		rules    string
+		expected string
+	}{
+		{
+
+			name:     "simple user",
+			rules:    `allow subject user cto@acme.com to manage petstore.pet;`,
+			expected: `allow subject user cto@acme.com to manage petstore.pet;`,
+		},
+		{
+
+			name:     "simple group",
+			rules:    `allow subject group managers to manage iam.*;`,
+			expected: `allow subject group managers to manage iam.*;`,
+		},
+		{
+			name:     "simple where clause",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.status == "available";`,
+			expected: `allow subject group customers to buy petstore.pet where (ctx.status == "available");`,
+		},
+		{
+			name:     "simple where clause",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.status != "available";`,
+			expected: `allow subject group customers to buy petstore.pet where (ctx.status != "available");`,
+		},
+		{
+			name:     "simple where clause",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.is_healthy == "true";`,
+			expected: `allow subject group customers to buy petstore.pet where (ctx.is_healthy == "true");`,
+		},
+	}
+
+	typs, err := types.NewTypeFromOpenAPIv3([]byte(typesContent))
+	if err != nil {
+		t.Fatalf("Swagger types error: %s", err)
+	}
+
+	for _, tst := range testcases {
+		t.Run(tst.name, func(t *testing.T) {
+			lxr := lexer.New(tst.rules)
+			psr := New(lxr, typs)
+
+			policies := psr.ParsePolicies()
+			checkParserErrors(t, psr)
+			if policies == nil {
+				t.Fatalf("ParsePolicies() returned nil")
+			}
+
+			if policies.String() != tst.expected {
+				t.Fatalf("actual does not match expected for: %s\nactual:   %s\nexpected: %s",
+					tst.rules, policies, tst.expected)
+			}
+
+		})
+	}
+}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -12,10 +12,12 @@ const (
 	EOF     = "EOF"
 	LITERAL = "LITERAL"
 
-	COMMENT          = "#"
-	IDENT            = "IDENT"
-	TYPE_PATTERN     = "TYPE_PATTERN"
-	DELIMETER        = ";"
+	COMMENT      = "#"
+	IDENT        = "IDENT"
+	TYPE_PATTERN = "TYPE_PATTERN"
+	DELIMETER    = ";"
+
+	// Operators
 	OP_EQUAL_TO      = "=="
 	OP_NOT_EQUAL     = "!="
 	OP_LESS_THAN     = "<"

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -1,0 +1,10 @@
+package types
+
+import (
+	"reflect"
+)
+
+// IsNilInterface returns whether the interface parameter is nil
+func IsNilInterface(i interface{}) bool {
+	return i == nil || reflect.ValueOf(i).IsNil()
+}

--- a/pkg/types/interface_test.go
+++ b/pkg/types/interface_test.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsNilInterface(t *testing.T) {
+	var nilError error
+
+	tests := []struct {
+		title    string
+		ptr      interface{}
+		expected bool
+	}{
+		{
+			title:    "nil constant should be nil interface",
+			ptr:      nil,
+			expected: true,
+		},
+		{
+			title:    "nil error variable should be nil interface",
+			ptr:      nilError,
+			expected: true,
+		},
+		{
+			title:    "typed nil variable should be nil interface",
+			ptr:      error(nil),
+			expected: true,
+		},
+		{
+			title:    "constructed error variable should not be nil interface",
+			ptr:      errors.New("hello"),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		actual := IsNilInterface(test.ptr)
+		if actual != test.expected {
+			t.Fatalf("%s: actual: %v  does not match  expected: %v",
+				test.title, actual, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
### DEMO - demo output changed to include parenthesis - no regressions in rego tests:
```
# wlu@rm-ml-wlu: make demo
./seal compile -s docs/source/examples/petstore/petstore.all.swagger -f docs/source/examples/petstore/petstore.all.seal | tee docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] logging level                                 logging.level=info

...

deny {
    seal_list_contains(input.subject.groups, `managers`)
    input.verb == `sell`
    re_match(`petstore.pet`, input.type)
(input.status != "available")
}
...

allow {
    seal_list_contains(input.subject.groups, `customers`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
(input.status == "available")
}

...

PASS: 7/7
+ git diff --exit-code petstore.all.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests
```