### PR TITLE
GH-68: allow `and` as conditional in where clause

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -54,6 +54,14 @@ allow {
 	input.status == "available"
 }
 
+allow {
+	seal_list_contains(input.subject.groups, `breeders_maltese`)
+	input.verb == `buy`
+	re_match(`petstore.pet`, input.type)
+	input.status == "reserved"
+	input.breed == "maltese"
+}
+
 # rego functions defined by seal
 
 # seal_list_contains returns true if elem exists in list

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -44,6 +44,13 @@ allow {
     re_match(`petstore.pet`, input.type)
 (input.status == "available")
 }
+allow {
+    seal_list_contains(input.subject.groups, `breeders_maltese`)
+    input.verb == `buy`
+    re_match(`petstore.pet`, input.type)
+(input.status == "reserved")
+(input.breed == "maltese")
+}
 
 # rego functions defined by seal
 

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -15,6 +15,7 @@ allow subject group everyone to inspect petstore.pet;
 allow subject group customers to read petstore.pet;
 
 allow subject group customers to buy petstore.pet where ctx.status == "available";
+allow subject group breeders_maltese to buy petstore.pet where ctx.status == "reserved" and ctx.breed == "maltese";
 
 # ==== WIP:
 #allow subject group everyone to manage petstore.order where ctx.buyer.email == subject.email;

--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -68,6 +68,8 @@ components:
       properties:
         id:
           type: string
+        breed:
+          type: string
         name:
           type: string
           example: "fido"

--- a/pkg/compiler/rego/rego.go
+++ b/pkg/compiler/rego/rego.go
@@ -198,6 +198,11 @@ func (c *CompilerRego) compileCondition(o ast.Condition, lvl int) (string, error
 		if err != nil {
 			return "", err
 		}
+
+		switch s.Token.Type {
+		case token.AND:
+			return fmt.Sprintf("%s\n%s", lhs, rhs), nil
+		}
 		return fmt.Sprintf("(%s %s %s)", lhs, s.Token.Literal, rhs), nil
 
 	default:

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -135,7 +135,30 @@ seal_list_contains(list, elem) {
 }
 `,
 		},
-		"products.inventory": {
+		"statement with and": {
+			packageName:  "products.inventory",
+			policyString: `allow subject group everyone to inspect products.inventory where ctx.id=="bar" and ctx.name=="foo";`,
+			result: `
+package products.inventory
+default allow = false
+default deny = false
+allow {
+    seal_list_contains(input.subject.groups, 'everyone')
+    input.verb == 'inspect'
+    re_match('products.inventory', input.type)
+(input.id == "bar")
+(input.name == "foo")
+}
+
+# rego functions defined by seal
+
+# seal_list_contains returns true if elem exists in list
+seal_list_contains(list, elem) {
+    list[_] = elem
+}
+`,
+		},
+		"multiple statements": {
 			packageName: "products.inventory",
 			policyString: `
 				allow subject group everyone to inspect products.inventory where ctx.id=="bar";

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -14,6 +14,7 @@ func TestNextToken(t *testing.T) {
 	allow subject group customers to buy petstore.pet where ctx.tag["color"] == "purple";
 	allow subject group everyone to read petstore.pet;
 	=== !! << >> == != < > <= >=
+        not and or
 	`
 
 	tests := []struct {
@@ -71,6 +72,10 @@ func TestNextToken(t *testing.T) {
 		{token.OP_GREATER_THAN, ">"},
 		{token.OP_LESS_EQUAL, "<="},
 		{token.OP_GREATER_EQUAL, ">="},
+
+		{token.NOT, "not"},
+		{token.AND, "and"},
+		{token.OR, "or"},
 	}
 
 	l := New(input)

--- a/pkg/parser/condition.go
+++ b/pkg/parser/condition.go
@@ -21,6 +21,8 @@ func (p *Parser) registerPrefixConditionParseFns() {
 
 	p.registerPrefixCondition(token.TYPE_PATTERN, p.parseIdentifier)
 	p.registerPrefixCondition(token.LITERAL, p.parseIdentifier)
+
+	// TODO GH-43: p.registerPrefixCondition(token.NOT, p.parseLogicalNot)
 }
 
 func (p *Parser) registerPrefixCondition(tokenType token.TokenType, fn prefixConditionParseFn) {
@@ -38,6 +40,9 @@ func (p *Parser) registerInfixConditionParseFns() {
 	p.registerInfixCondition(token.OP_GREATER_THAN, p.parseInfixCondition)
 	p.registerInfixCondition(token.OP_LESS_EQUAL, p.parseInfixCondition)
 	p.registerInfixCondition(token.OP_GREATER_EQUAL, p.parseInfixCondition)
+
+	p.registerInfixCondition(token.AND, p.parseInfixCondition)
+	// TODO GH-42: p.registerInfixCondition(token.OR, p.parseInfixCondition)
 }
 
 func (p *Parser) registerInfixCondition(tokenType token.TokenType, fn infixConditionParseFn) {
@@ -99,6 +104,9 @@ func (p *Parser) parseInfixCondition(left ast.Condition) ast.Condition {
 const (
 	_ int = iota
 	PRECEDENCE_LOWEST
+	PRECEDENCE_OR          // logical or
+	PRECEDENCE_AND         // logical and
+	PRECEDENCE_NOT         // logical not
 	PRECEDENCE_EQUALS      // ==
 	PRECEDENCE_LESSGREATER // > or <
 	PRECEDENCE_SUM         // +
@@ -108,6 +116,9 @@ const (
 )
 
 var precedences = map[token.TokenType]int{
+	token.OR:               PRECEDENCE_OR,
+	token.AND:              PRECEDENCE_AND,
+	token.NOT:              PRECEDENCE_NOT,
 	token.OP_EQUAL_TO:      PRECEDENCE_EQUALS,
 	token.OP_NOT_EQUAL:     PRECEDENCE_EQUALS,
 	token.OP_LESS_THAN:     PRECEDENCE_LESSGREATER,

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/infobloxopen/seal/pkg/lexer"
 	"github.com/infobloxopen/seal/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 func TestWhereClause(t *testing.T) {
+	logrus.StandardLogger().SetLevel(logrus.DebugLevel)
+
 	typesContent := `
 openapi: "3.0.0"
 components:
@@ -76,19 +79,29 @@ components:
 			expected: `allow subject group managers to manage iam.*;`,
 		},
 		{
-			name:     "simple where clause",
+			name:     "simple where clause compare equal",
 			rules:    `allow subject group customers to buy petstore.pet where ctx.status == "available";`,
 			expected: `allow subject group customers to buy petstore.pet where (ctx.status == "available");`,
 		},
 		{
-			name:     "simple where clause",
+			name:     "simple where clause compare not equal",
 			rules:    `allow subject group customers to buy petstore.pet where ctx.status != "available";`,
 			expected: `allow subject group customers to buy petstore.pet where (ctx.status != "available");`,
 		},
 		{
-			name:     "simple where clause",
+			name:     "simple where clause compare bool", // TODO: bool needs to be bare word in OPA
 			rules:    `allow subject group customers to buy petstore.pet where ctx.is_healthy == "true";`,
 			expected: `allow subject group customers to buy petstore.pet where (ctx.is_healthy == "true");`,
+		},
+		{
+			name:     "single where clause and",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.status == "available" and ctx.is_healthy == "true";`,
+			expected: `allow subject group customers to buy petstore.pet where ((ctx.status == "available") and (ctx.is_healthy == "true"));`,
+		},
+		{
+			name:     "left associative where clause and",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.status == "available" and ctx.is_healthy == "true" and ctx.name == "fido";`,
+			expected: `allow subject group customers to buy petstore.pet where (((ctx.status == "available") and (ctx.is_healthy == "true")) and (ctx.name == "fido"));`,
 		},
 	}
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -1,5 +1,9 @@
 package token
 
+import (
+	"github.com/sirupsen/logrus"
+)
+
 type TokenType string
 
 type Token struct {
@@ -34,6 +38,7 @@ const (
 	USER    = "user"
 	TO      = "to"
 	WHERE   = "where"
+	NOT     = "not"
 	AND     = "and"
 	OR      = "or"
 )
@@ -45,6 +50,7 @@ var keywords = map[string]TokenType{
 	"group":   GROUP,
 	"to":      TO,
 	"where":   WHERE,
+	"not":     NOT,
 	"and":     AND,
 	"or":      OR,
 }
@@ -60,6 +66,7 @@ func LookupIdent(ident string) TokenType {
 }
 
 func LookupOperatorComparison(op string) TokenType {
+	logrus.WithField("op", op).Debug("LookupOperatorComparison")
 	switch op {
 	default:
 		return ILLEGAL
@@ -75,6 +82,32 @@ func LookupOperatorComparison(op string) TokenType {
 	return TokenType(op)
 }
 
+func LookupOperatorLogical(op string) TokenType {
+	logrus.WithField("op", op).Debug("LookupOperatorLogical")
+	switch op {
+	default:
+		return ILLEGAL
+
+	case NOT:
+	case AND:
+	case OR:
+	}
+
+	return TokenType(op)
+}
+
 func LookupOperator(op string) TokenType {
-	return LookupOperatorComparison(op)
+	logrus.WithField("op", op).Debug("LookupOperator")
+	type funcLookupOperator func(string) TokenType
+
+	for _, f := range []funcLookupOperator{
+		LookupOperatorComparison,
+		LookupOperatorLogical,
+	} {
+		if typ := f(op); typ != ILLEGAL {
+			return typ
+		}
+	}
+
+	return ILLEGAL
 }

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -1,0 +1,78 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLookupOperator(t *testing.T) {
+	logrus.StandardLogger().SetLevel(logrus.DebugLevel)
+
+	testcases := []struct {
+		name     string
+		tok      string
+		expected TokenType
+	}{
+		{
+			name:     "invalid empty",
+			expected: ILLEGAL,
+		},
+		{
+			name:     "equal to",
+			tok:      "==",
+			expected: OP_EQUAL_TO,
+		},
+		{
+			name:     "not equal",
+			tok:      "!=",
+			expected: OP_NOT_EQUAL,
+		},
+		{
+			name:     "less than",
+			tok:      "<",
+			expected: OP_LESS_THAN,
+		},
+		{
+			name:     "greater than",
+			tok:      ">",
+			expected: OP_GREATER_THAN,
+		},
+		{
+			name:     "less than or equal to",
+			tok:      "<=",
+			expected: OP_LESS_EQUAL,
+		},
+		{
+			name:     "greater than or equal to",
+			tok:      ">=",
+			expected: OP_GREATER_EQUAL,
+		},
+		{
+			name:     "and",
+			tok:      "and",
+			expected: AND,
+		},
+		{
+			name:     "not",
+			tok:      "not",
+			expected: NOT,
+		},
+		{
+			name:     "or",
+			tok:      "or",
+			expected: OR,
+		},
+	}
+
+	for _, tst := range testcases {
+		t.Run(tst.name, func(t *testing.T) {
+			actual := LookupOperator(tst.tok)
+			if actual != tst.expected {
+				t.Fatalf("actual does not match expected: actual: %s expected: %s",
+					actual, tst.expected)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
### DEMO - added support for `and`:
`allow subject group breeders_maltese to buy petstore.pet where ctx.status == "reserved" and ctx.breed == "maltese";`
```
# wlu@rm-ml-wlu: make demo
./seal compile -s docs/source/examples/petstore/petstore.all.swagger -f docs/source/examples/petstore/petstore.all.seal | tee docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] logging level                                 logging.level=info

package petstore.all

...

allow {
    seal_list_contains(input.subject.groups, `breeders_maltese`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
(input.status == "reserved")
(input.breed == "maltese")
}

...

+ docker run -v /Users/wlu/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest test -v petstore.all.rego petstore.all.test.rego petstore.all.mock.json
data.petstore.all.test_banned_deny: PASS (455.2µs)
data.petstore.all.test_banned_deny_negative: PASS (339.6µs)
data.petstore.all.test_inspect: PASS (323.7µs)
data.petstore.all.test_inspect_negative: PASS (282.4µs)
data.petstore.all.test_read: PASS (286.1µs)
data.petstore.all.test_read_negative: PASS (236.8µs)
data.petstore.all.test_manage_cto: PASS (263.2µs)
--------------------------------------------------------------------------------
PASS: 7/7
+ git diff --exit-code petstore.all.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests

```