### PR TITLE
GH-43: allow not as conditional in where clause

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -17,6 +17,14 @@ deny {
 	input.status != "available"
 }
 
+deny {
+	seal_list_contains(input.subject.groups, `fussy`)
+	input.verb == `buy`
+	re_match(`petstore.pet`, input.type)
+	not input.neutered
+	not input.potty_trained
+}
+
 allow {
 	seal_list_contains(input.subject.groups, `operators`)
 	input.verb == `use`

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -11,7 +11,14 @@ deny {
     seal_list_contains(input.subject.groups, `managers`)
     input.verb == `sell`
     re_match(`petstore.pet`, input.type)
-(input.status != "available")
+input.status != "available"
+}
+deny {
+    seal_list_contains(input.subject.groups, `fussy`)
+    input.verb == `buy`
+    re_match(`petstore.pet`, input.type)
+not input.neutered
+not input.potty_trained
 }
 allow {
     seal_list_contains(input.subject.groups, `operators`)
@@ -42,14 +49,14 @@ allow {
     seal_list_contains(input.subject.groups, `customers`)
     input.verb == `buy`
     re_match(`petstore.pet`, input.type)
-(input.status == "available")
+input.status == "available"
 }
 allow {
     seal_list_contains(input.subject.groups, `breeders_maltese`)
     input.verb == `buy`
     re_match(`petstore.pet`, input.type)
-(input.status == "reserved")
-(input.breed == "maltese")
+input.status == "reserved"
+input.breed == "maltese"
 }
 
 # rego functions defined by seal

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,5 +1,6 @@
 deny subject group banned to manage petstore.*;
 deny subject group managers to sell petstore.pet where ctx.status != "available";
+deny subject group fussy to buy petstore.pet where not ctx.neutered and not ctx.potty_trained;
 
 # ==== WIP:
 #deny (notify="true") subject group everyone to provision petstore.pet

--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -73,6 +73,10 @@ components:
         name:
           type: string
           example: "fido"
+        neutered:
+          type: boolean
+        potty_trained:
+          type: boolean
         status:
           type: string
           description: "pet status in the store"

--- a/pkg/compiler/rego/rego.go
+++ b/pkg/compiler/rego/rego.go
@@ -187,7 +187,7 @@ func (c *CompilerRego) compileCondition(o ast.Condition, lvl int) (string, error
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("(%s %s)", s.Token, rhs), nil
+		return fmt.Sprintf("%s %s", s.Token.Literal, rhs), nil
 
 	case *ast.InfixCondition:
 		lhs, err := c.compileCondition(s.Left, lvl+1)
@@ -202,8 +202,10 @@ func (c *CompilerRego) compileCondition(o ast.Condition, lvl int) (string, error
 		switch s.Token.Type {
 		case token.AND:
 			return fmt.Sprintf("%s\n%s", lhs, rhs), nil
+		case token.OR:
+			return fmt.Sprintf("# TODO: support or: %s or %s", lhs, rhs), nil
 		}
-		return fmt.Sprintf("(%s %s %s)", lhs, s.Token.Literal, rhs), nil
+		return fmt.Sprintf("%s %s %s", lhs, s.Token.Literal, rhs), nil
 
 	default:
 		logrus.WithFields(logrus.Fields{

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWhereClause(t *testing.T) {
-	logrus.StandardLogger().SetLevel(logrus.DebugLevel)
+	logrus.StandardLogger().SetLevel(logrus.InfoLevel)
 
 	typesContent := `
 openapi: "3.0.0"

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLookupOperator(t *testing.T) {
-	logrus.StandardLogger().SetLevel(logrus.DebugLevel)
+	logrus.StandardLogger().SetLevel(logrus.InfoLevel)
 
 	testcases := []struct {
 		name     string
@@ -49,14 +49,14 @@ func TestLookupOperator(t *testing.T) {
 			expected: OP_GREATER_EQUAL,
 		},
 		{
-			name:     "and",
-			tok:      "and",
-			expected: AND,
-		},
-		{
 			name:     "not",
 			tok:      "not",
 			expected: NOT,
+		},
+		{
+			name:     "and",
+			tok:      "and",
+			expected: AND,
 		},
 		{
 			name:     "or",


### PR DESCRIPTION
### DEMO:
`deny subject group fussy to buy petstore.pet where not ctx.neutered and not ctx.potty_trained;`
```
# wlu@rm-ml-wlu: make demo

...

deny {
    seal_list_contains(input.subject.groups, `fussy`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
not input.neutered
not input.potty_trained
}

...

### petstore example passed REGO OPA tests
```