### PR TITLE
GH-72: allow parens as grouped conditions in where clause

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -21,8 +21,29 @@ deny {
 	seal_list_contains(input.subject.groups, `fussy`)
 	input.verb == `buy`
 	re_match(`petstore.pet`, input.type)
-	not input.neutered
-	not input.potty_trained
+	not line3_not1_cnd
+}
+
+line3_not1_cnd {
+	input.neutered
+
+	not line3_not2_cnd
+}
+
+line3_not2_cnd {
+	input.potty_trained
+}
+
+allow {
+	seal_list_contains(input.subject.groups, `fussy`)
+	input.verb == `buy`
+	re_match(`petstore.pet`, input.type)
+	not line4_not1_cnd
+}
+
+line4_not1_cnd {
+	input.neutered
+	input.potty_trained
 }
 
 allow {

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -17,8 +17,27 @@ deny {
     seal_list_contains(input.subject.groups, `fussy`)
     input.verb == `buy`
     re_match(`petstore.pet`, input.type)
-not input.neutered
-not input.potty_trained
+not line3_not1_cnd
+}
+line3_not1_cnd {
+input.neutered
+
+not line3_not2_cnd
+}
+line3_not2_cnd {
+input.potty_trained
+
+}
+allow {
+    seal_list_contains(input.subject.groups, `fussy`)
+    input.verb == `buy`
+    re_match(`petstore.pet`, input.type)
+not line4_not1_cnd
+}
+line4_not1_cnd {
+input.neutered
+input.potty_trained
+
 }
 allow {
     seal_list_contains(input.subject.groups, `operators`)

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,6 +1,7 @@
 deny subject group banned to manage petstore.*;
 deny subject group managers to sell petstore.pet where ctx.status != "available";
 deny subject group fussy to buy petstore.pet where not ctx.neutered and not ctx.potty_trained;
+allow subject group fussy to buy petstore.pet where not (ctx.neutered and ctx.potty_trained);
 
 # ==== WIP:
 #deny (notify="true") subject group everyone to provision petstore.pet

--- a/main.go
+++ b/main.go
@@ -24,4 +24,3 @@ import (
 func main() {
 	cmd.Execute(context.Background())
 }
-

--- a/pkg/parser/condition.go
+++ b/pkg/parser/condition.go
@@ -23,6 +23,7 @@ func (p *Parser) registerPrefixConditionParseFns() {
 	p.registerPrefixCondition(token.LITERAL, p.parseIdentifier)
 
 	p.registerPrefixCondition(token.NOT, p.parsePrefixCondition)
+	p.registerPrefixCondition(token.OPEN_PAREN, p.parseGroupedCondition)
 }
 
 func (p *Parser) registerPrefixCondition(tokenType token.TokenType, fn prefixConditionParseFn) {
@@ -113,6 +114,17 @@ func (p *Parser) parseInfixCondition(left ast.Condition) ast.Condition {
 	p.nextToken()
 	condition.Right = p.parseCondition(precedence)
 	return condition
+}
+
+func (p *Parser) parseGroupedCondition() ast.Condition {
+	p.nextToken()
+
+	cnd := p.parseCondition(PRECEDENCE_LOWEST)
+	if !p.expectPeek(token.CLOSE_PAREN) {
+		return nil
+	}
+
+	return cnd
 }
 
 // precedences

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -103,6 +103,16 @@ components:
 			rules:    `allow subject group customers to buy petstore.pet where ctx.status == "available" and ctx.is_healthy == "true" and ctx.name == "fido";`,
 			expected: `allow subject group customers to buy petstore.pet where (((ctx.status == "available") and (ctx.is_healthy == "true")) and (ctx.name == "fido"));`,
 		},
+		{
+			name:     "where clause grouped conditions",
+			rules:    `allow subject group customers to buy petstore.pet where not (ctx.status == "available" and ctx.is_healthy == "true");`,
+			expected: `allow subject group customers to buy petstore.pet where (not((ctx.status == "available") and (ctx.is_healthy == "true")));`,
+		},
+		{
+			name:     "where clause multiple grouped conditions",
+			rules:    `allow subject group customers to buy petstore.pet where not ( (not (ctx.status == "available" and ctx.is_healthy == "true")) and (not (ctx.id == "foo" and ctx.name == "bar")) );`,
+			expected: `allow subject group customers to buy petstore.pet where (not((not((ctx.status == "available") and (ctx.is_healthy == "true"))) and (not((ctx.id == "foo") and (ctx.name == "bar")))));`,
+		},
 	}
 
 	typs, err := types.NewTypeFromOpenAPIv3([]byte(typesContent))


### PR DESCRIPTION
### DEMO:
`allow subject group fussy to buy petstore.pet where not (ctx.neutered and ctx.potty_trained);`
```
# wlu@rm-ml-wlu: make demo
...
allow {
    seal_list_contains(input.subject.groups, `fussy`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
not line4_not1_cnd
}
line4_not1_cnd {
input.neutered
input.potty_trained

}
...
### petstore example passed REGO OPA tests
```