### PR TITLE
added make bench to benchmark rego

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,15 @@ petstore: seal
 	./docs/source/examples/check-rego.sh $(dir)
 	git diff --exit-code $(dir)
 	@echo "### petstore example passed REGO OPA tests"
+
+.PHONY: bench
+bench: bench-petstore
+bench-petstore:
+bench-petstore: dir=docs/source/examples/petstore
+bench-petstore: seal
+	./seal compile -s $(dir)/petstore.all.swagger -f $(dir)/petstore.all.seal | tee $(dir)/petstore.all.rego.compiled
+	cp $(dir)/petstore.all.rego.compiled $(dir)/petstore.all.rego
+	# beware that bench-rego.sh reformats the compiled rego files...
+	./docs/source/examples/bench-rego.sh $(dir)
+	git diff --exit-code $(dir)
+	@echo "### petstore benchmarks successfully completed"

--- a/docs/source/examples/bench-rego.sh
+++ b/docs/source/examples/bench-rego.sh
@@ -1,0 +1,1 @@
+check-rego.sh

--- a/docs/source/examples/check-rego.sh
+++ b/docs/source/examples/check-rego.sh
@@ -24,7 +24,15 @@ TOP=$(cd $1 && /bin/pwd)
 cd ${TOP} || die "unable to cd to dir: ${TOP}"
 
 docker run -v ${TOP}:/data -w /data "${IMAGE}" fmt -w .
-docker run -v ${TOP}:/data -w /data "${IMAGE}" test -v *.rego *.json
+
+case "$(basename $0)" in
+bench-*)
+    docker run --rm -v ${TOP}:/data -w /data "${IMAGE}" test -v --bench --count=${OPA_BENCH_COUNT:-2} -t ${OPA_BENCH_TIMEOUT:-10s} *.rego *.json
+    ;;
+*)
+    docker run --rm -v ${TOP}:/data -w /data "${IMAGE}" test -v *.rego *.json
+    ;;
+esac
 
 git diff --exit-code *.rego || die "opa formatting found whitespace changes, please commit"
 


### PR DESCRIPTION
### DEMO:
```
$ make bench
...
+ docker run --rm -v /Users/wlu/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest test -v --bench --count=2 -t 10s petstore.all.rego petstore.all.test.rego petstore.all.mock.json

data.petstore.all.test_banned_deny	   25988	     46659 ns/op	     38229 timer_rego_query_eval_ns/op	   12474 B/op	     218 allocs/op
data.petstore.all.test_banned_deny_negative	   28107	     42348 ns/op	     34318 timer_rego_query_eval_ns/op	   13373 B/op	     223 allocs/op
data.petstore.all.test_inspect	   25960	     46686 ns/op	     38174 timer_rego_query_eval_ns/op	   12385 B/op	     218 allocs/op
data.petstore.all.test_inspect_negative	   26631	     44543 ns/op	     35882 timer_rego_query_eval_ns/op	   13453 B/op	     226 allocs/op
data.petstore.all.test_read	   25339	     46973 ns/op	     38615 timer_rego_query_eval_ns/op	   12528 B/op	     221 allocs/op
data.petstore.all.test_read_negative	   26592	     45102 ns/op	     36848 timer_rego_query_eval_ns/op	   13613 B/op	     229 allocs/op
data.petstore.all.test_manage_cto	   24342	     49404 ns/op	     41016 timer_rego_query_eval_ns/op	   13839 B/op	     238 allocs/op
--------------------------------------------------------------------------------
PASS: 7/7
data.petstore.all.test_banned_deny	   25442	     47807 ns/op	     39083 timer_rego_query_eval_ns/op	   12461 B/op	     218 allocs/op
...
--------------------------------------------------------------------------------
PASS: 7/7
...
```