### PR TITLE
GH-84: allow integer to be compared in where clause conditional

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -12,6 +12,13 @@ deny {
 }
 
 deny {
+	seal_list_contains(input.subject.groups, `everyone`)
+	input.verb == `buy`
+	re_match(`petstore.pet`, input.type)
+	input.age <= 2
+}
+
+deny {
 	seal_list_contains(input.subject.groups, `banned`)
 	input.verb == `manage`
 	re_match(`petstore.*`, input.type)
@@ -28,16 +35,16 @@ deny {
 	seal_list_contains(input.subject.groups, `fussy`)
 	input.verb == `buy`
 	re_match(`petstore.pet`, input.type)
-	not line4_not1_cnd
+	not line5_not1_cnd
 }
 
-line4_not1_cnd {
+line5_not1_cnd {
 	input.neutered
 
-	not line4_not2_cnd
+	not line5_not2_cnd
 }
 
-line4_not2_cnd {
+line5_not2_cnd {
 	input.potty_trained
 }
 
@@ -45,10 +52,10 @@ allow {
 	seal_list_contains(input.subject.groups, `fussy`)
 	input.verb == `buy`
 	re_match(`petstore.pet`, input.type)
-	not line5_not1_cnd
+	not line6_not1_cnd
 }
 
-line5_not1_cnd {
+line6_not1_cnd {
 	input.neutered
 	input.potty_trained
 }

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -10,6 +10,13 @@ deny {
 }
 
 deny {
+    seal_list_contains(input.subject.groups, `everyone`)
+    input.verb == `buy`
+    re_match(`petstore.pet`, input.type)
+    input.age <= 2
+}
+
+deny {
     seal_list_contains(input.subject.groups, `banned`)
     input.verb == `manage`
     re_match(`petstore.*`, input.type)
@@ -26,16 +33,16 @@ deny {
     seal_list_contains(input.subject.groups, `fussy`)
     input.verb == `buy`
     re_match(`petstore.pet`, input.type)
-    not line4_not1_cnd
+    not line5_not1_cnd
 }
 
-line4_not1_cnd {
+line5_not1_cnd {
     input.neutered
 
-    not line4_not2_cnd
+    not line5_not2_cnd
 }
 
-line4_not2_cnd {
+line5_not2_cnd {
     input.potty_trained
 }
 
@@ -43,10 +50,10 @@ allow {
     seal_list_contains(input.subject.groups, `fussy`)
     input.verb == `buy`
     re_match(`petstore.pet`, input.type)
-    not line5_not1_cnd
+    not line6_not1_cnd
 }
 
-line5_not1_cnd {
+line6_not1_cnd {
     input.neutered
     input.potty_trained
 }

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,5 +1,5 @@
 deny subject group everyone to use petstore.* where subject.iss != "petstore.com";
-
+deny subject group everyone to buy petstore.pet where ctx.age <= 2;
 deny subject group banned to manage petstore.*;
 deny subject group managers to sell petstore.pet where ctx.status != "available";
 deny subject group fussy to buy petstore.pet where not ctx.neutered and not ctx.potty_trained;

--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -68,6 +68,11 @@ components:
       properties:
         id:
           type: string
+        age:
+          type: integer
+          format: int32
+          example: 2
+          description: "age of pet in months"
         breed:
           type: string
         name:

--- a/docs/source/examples/petstore/petstore.jwt.swagger
+++ b/docs/source/examples/petstore/petstore.jwt.swagger
@@ -1,3 +1,5 @@
+# JSON Web Token (JWT)
+#   https://tools.ietf.org/html/rfc7519
 openapi: "3.0.0"
 components:
   schemas:
@@ -12,19 +14,27 @@ components:
           type: string
         iss:
           type: string
+          example: "petstore.swagger.io"
+          description: "(issuer) claim identifies the principal that issued the JWT"
         sub:
           type: string
+          example: "cto@petstore.swagger.io"
+          description: "(subject) claim identifies the principal that is the subject of the JWT"
         aud:
           type: string
+          example: "iam"
+          description: "(audience) claim identifies the recipients that the JWT is intended for"
         exp:
           type: integer
           format: int32
         nbf:
           type: integer
           format: int32
-        jti:
-          type: string
         iat:
           type: integer
           format: int32
+        jti:
+          type: string
+          example: "id-42"
+          description: "(JWT ID) claim provides a unique identifier for the JWT"
       x-seal-type: none

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -82,6 +82,18 @@ func (slf *Identifier) GetTypes() []*Identifier {
 	return []*Identifier{}
 }
 
+type IntegerLiteral struct {
+	Token token.Token
+	Value int64
+}
+
+func (slf *IntegerLiteral) conditionNode()       {}
+func (slf *IntegerLiteral) TokenLiteral() string { return slf.Token.Literal }
+func (slf *IntegerLiteral) String() string       { return slf.Token.Literal }
+func (slf *IntegerLiteral) GetTypes() []*Identifier {
+	return []*Identifier{}
+}
+
 type ActionStatement struct {
 	Token       token.Token
 	Action      *Identifier

--- a/pkg/compiler/rego/rego.go
+++ b/pkg/compiler/rego/rego.go
@@ -245,6 +245,10 @@ func (c *CompilerRego) compileCondition(o ast.Condition, lvl, lineNum int) (stri
 
 		return id, nil
 
+	case *ast.IntegerLiteral:
+		id := s.Token.Literal
+		return id, nil
+
 	case *ast.PrefixCondition:
 		rhs, err := c.compileCondition(s.Right, lvl+1, lineNum)
 		if err != nil {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -67,6 +67,11 @@ func (l *Lexer) NextToken() token.Token {
 			}
 			return tok
 		}
+		if isDigit(l.ch) {
+			tok.Type = token.INT
+			tok.Literal = l.readNumber()
+			return tok
+		}
 		if isOperator(l.ch) {
 			tok.Literal = l.readOperator()
 			tok.Type = token.LookupOperator(tok.Literal)
@@ -81,6 +86,14 @@ func (l *Lexer) NextToken() token.Token {
 func (l *Lexer) readIdentifier() string {
 	start := l.position
 	for isIdentifierChar(l.ch) {
+		l.readChar()
+	}
+	return l.input[start:l.position]
+}
+
+func (l *Lexer) readNumber() string {
+	start := l.position
+	for isDigit(l.ch) {
 		l.readChar()
 	}
 	return l.input[start:l.position]
@@ -114,7 +127,7 @@ func isIdentifierChar(ch byte) bool {
 
 func isLiteralChar(ch byte) bool {
 	// ToDo (suggestion): return ch != '"'
-	return isLetter(ch) || isNumber(ch) || ch == '.'
+	return isLetter(ch) || isDigit(ch) || ch == '.'
 }
 
 func isOperator(ch byte) bool {
@@ -141,7 +154,7 @@ func isLetter(ch byte) bool {
 	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
 }
 
-func isNumber(ch byte) bool {
+func isDigit(ch byte) bool {
 	return '0' <= ch && ch <= '9'
 }
 

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -13,6 +13,7 @@ func TestNextToken(t *testing.T) {
 	allow subject user cto@petstore.swagger.io to manage petstore.*;
 	allow subject group customers to buy petstore.pet where ctx.tag["color"] == "purple";
 	allow subject group everyone to read petstore.pet;
+        deny subject group everyone to buy petstore.pet where ctx.age < 2;
 	=== !! << >> == != < > <= >=
         not and or
 	`
@@ -60,6 +61,19 @@ func TestNextToken(t *testing.T) {
 		{token.TO, "to"},
 		{token.IDENT, "read"},
 		{token.TYPE_PATTERN, "petstore.pet"},
+		{token.DELIMETER, ";"},
+
+		{token.IDENT, "deny"},
+		{token.SUBJECT, "subject"},
+		{token.GROUP, "group"},
+		{token.IDENT, "everyone"},
+		{token.TO, "to"},
+		{token.IDENT, "buy"},
+		{token.TYPE_PATTERN, "petstore.pet"},
+		{token.WHERE, "where"},
+		{token.TYPE_PATTERN, "ctx.age"},
+		{token.OP_LESS_THAN, "<"},
+		{token.INT, "2"},
 		{token.DELIMETER, ";"},
 
 		{token.ILLEGAL, "==="},

--- a/pkg/parser/condition.go
+++ b/pkg/parser/condition.go
@@ -4,6 +4,7 @@ package parser
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/infobloxopen/seal/pkg/ast"
 	"github.com/infobloxopen/seal/pkg/token"
@@ -21,6 +22,7 @@ func (p *Parser) registerPrefixConditionParseFns() {
 
 	p.registerPrefixCondition(token.TYPE_PATTERN, p.parseIdentifier)
 	p.registerPrefixCondition(token.LITERAL, p.parseIdentifier)
+	p.registerPrefixCondition(token.INT, p.parseIntegerLiteral)
 
 	p.registerPrefixCondition(token.NOT, p.parsePrefixCondition)
 	p.registerPrefixCondition(token.OPEN_PAREN, p.parseGroupedCondition)
@@ -53,6 +55,21 @@ func (p *Parser) registerInfixCondition(tokenType token.TokenType, fn infixCondi
 // parsers
 func (p *Parser) parseIdentifier() ast.Condition {
 	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseIntegerLiteral() ast.Condition {
+	lit := &ast.IntegerLiteral{Token: p.curToken}
+
+	value, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
+	if err != nil {
+		msg := fmt.Sprintf("could not parse %q as integer", p.curToken.Literal)
+		p.errors = append(p.errors, msg)
+		return nil
+	}
+
+	lit.Value = value
+
+	return lit
 }
 
 func (p *Parser) parseLiteral() ast.Condition {

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -40,6 +40,9 @@ components:
           type: string
         status:
           type: string
+        age:    # months
+          type: integer
+          format: int32
         is_healthy:
           type: bool
     iam.user:
@@ -87,6 +90,11 @@ components:
 			name:     "simple where clause compare not equal",
 			rules:    `allow subject group customers to buy petstore.pet where ctx.status != "available";`,
 			expected: `allow subject group customers to buy petstore.pet where (ctx.status != "available");`,
+		},
+		{
+			name:     "simple where clause compare int",
+			rules:    `allow subject group customers to buy petstore.pet where ctx.age > 2;`,
+			expected: `allow subject group customers to buy petstore.pet where (ctx.age > 2);`,
 		},
 		{
 			name:     "simple where clause compare bool", // TODO: bool needs to be bare word in OPA

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -18,6 +18,7 @@ const (
 
 	COMMENT      = "#"
 	IDENT        = "IDENT"
+	INT          = "INT" // 1343456
 	TYPE_PATTERN = "TYPE_PATTERN"
 	DELIMETER    = ";"
 


### PR DESCRIPTION
### DEMO:
rule:
```
deny subject group everyone to buy petstore.pet where ctx.age <= 2;
```

test:
```
# wlu@rm-ml-wlu: make demo
...

deny {
    seal_list_contains(input.subject.groups, `everyone`)
    input.verb == `buy`
    re_match(`petstore.pet`, input.type)
    input.age <= 2
}

...
### petstore example passed REGO OPA tests
```