### PR TITLE
GH-90: replaced petstore.com with petstore.swagger.io; generate jwt in rego tests

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -8,7 +8,7 @@ deny {
 	seal_list_contains(input.subject.groups, `everyone`)
 	input.verb == `use`
 	re_match(`petstore.*`, input.type)
-	seal_subject.iss != "petstore.com"
+	seal_subject.iss != "petstore.swagger.io"
 }
 
 deny {

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -6,7 +6,7 @@ deny {
     seal_list_contains(input.subject.groups, `everyone`)
     input.verb == `use`
     re_match(`petstore.*`, input.type)
-    seal_subject.iss != "petstore.com"
+    seal_subject.iss != "petstore.swagger.io"
 }
 
 deny {

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,4 +1,4 @@
-deny subject group everyone to use petstore.* where subject.iss != "petstore.com";
+deny subject group everyone to use petstore.* where subject.iss != "petstore.swagger.io";
 deny subject group everyone to buy petstore.pet where ctx.age <= 2;
 deny subject group banned to manage petstore.*;
 deny subject group managers to sell petstore.pet where ctx.status != "available";


### PR DESCRIPTION
### DEMO:

old hardcoded jwt was used:
```
test_use_petstore_jwt {
        in := {
...
              "jwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJub3RfcGV0c3RvcmUuY29tIn0.iEsWURIWWbd4LV4UAyU7SPufo9pD5qcGLnCmqxxQExo",
```

generate jwt from claims for use in tests:
```
                "jwt": sealtest_jwt_encode_sign({
                        "iss": "not_petstore.swagger.io",
                        "sub": "wiley-e-coyote@acme.com",
                        "groups": ["everyone", "test"],
                }),
```

tests pass:
```
# wlu@rm-ml-wlu: make demo
...
data.petstore.all.test_use_petstore_jwt: PASS (910.2µs)
data.petstore.all.test_use_petstore_jwt_negative: PASS (552µs)
...
### petstore example passed REGO OPA tests
```