### PR TITLE
#85 isLiteralChar adjustment

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -126,8 +126,7 @@ func isIdentifierChar(ch byte) bool {
 }
 
 func isLiteralChar(ch byte) bool {
-	// ToDo (suggestion): return ch != '"'
-	return isLetter(ch) || isDigit(ch) || ch == '.'
+	return ch != '"'
 }
 
 func isOperator(ch byte) bool {


### PR DESCRIPTION
is it needed to support char escaping (mean strings like `"some \"text\" with \"special\" chars"` ?