### PR TITLE
GH-119: Return offending swagger yaml in error msg on yaml unmarshal error

### DIFF
--- a/pkg/compiler/policy_compiler.go
+++ b/pkg/compiler/policy_compiler.go
@@ -54,7 +54,7 @@ func (rc *PolicyCompiler) mergeSwaggers(swaggerTypes ...string) (string, error) 
 	for i := len(swaggerTypes) - 1; i >= 0; i-- {
 		psw := &openapi3.Swagger{}
 		if err := yaml.Unmarshal([]byte(swaggerTypes[i]), psw); err != nil {
-			return "", fmt.Errorf("Error in sagger #%d: %s", i, err.Error())
+			return "", fmt.Errorf("Swagger yaml unmarshal error: %s:\n%s", err.Error(), swaggerTypes[i])
 		}
 		if rSw == nil {
 			rSw = psw


### PR DESCRIPTION
DEMO:
FATA[0000] could not create policy compiler              error="Swagger yaml unmarshal error: error converting YAML to JSON: yaml: line 12: mapping values are not allowed in this context:\n# This is a bad swagger, there should be no \"none\" after \"bad.widget:\"\nopenapi: \"3.0.0\"\ncomponents:\n  schemas:\n    allow:\n      type: object\n      properties:\n        notify:\n          type: boolean\n      x-seal-type: action\n    bad.widget: none\n      x-seal-default-action: allow\n      x-seal-actions:\n      - allow\n      x-seal-verbs:\n      - throw\n      - swim\n      type: object\n      properties:\n        id:\n          type: string\n        name:\n          type: string\n\n"