### PR TITLE
GH-104: fixed docs to define verb to permission mappings via maps in swagger

### DIFF
--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -7,10 +7,10 @@ components:
     #  type: object
     #  x-seal-type: verbs
     #  x-seal-verbs:
-    #  - inspect:   [ "list", "watch" ]
-    #  - read:      [ "get", "list", "watch" ]
-    #  - use:       [ "update", "get", "list", "watch" ]
-    #  - manage:    [ "create", "delete", "update", "get", "list", "watch" ]
+    #    inspect:   [ "list", "watch" ]
+    #    read:      [ "get", "list", "watch" ]
+    #    use:       [ "update", "get", "list", "watch" ]
+    #    manage:    [ "create", "delete", "update", "get", "list", "watch" ]
     allow:
       type: object
       properties:
@@ -61,13 +61,13 @@ components:
       - ship
       - deliver
       # TODO: GH-104
-      #- inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
-      #- read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
-      #- use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
-      #- manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      #- approve:   [ "approve" ]
-      #- ship:      [ "ship" ]
-      #- deliver:   [ "deliver" ]
+      # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
+      # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
+      # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
+      # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
+      # approve:   [ "approve" ]
+      # ship:      [ "ship" ]
+      # deliver:   [ "deliver" ]
       x-seal-default-action: deny
     petstore.pet:
       type: object
@@ -83,13 +83,13 @@ components:
       - buy
       - sell
       # TODO: GH-104
-      #- inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
-      #- read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
-      #- use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
-      #- manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      #- provision: [ "provision" ]
-      #- buy:       [ "buy" ]
-      #- sell:      [ "sell" ]
+      # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
+      # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
+      # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
+      # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
+      # provision: [ "provision" ]
+      # buy:       [ "buy" ]
+      # sell:      [ "sell" ]
       x-seal-default-action: deny
       properties:
         id:
@@ -151,11 +151,11 @@ components:
       - manage
       - sign_in
       # TODO: GH-104
-      #- inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
-      #- read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
-      #- use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
-      #- manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      #- sign_in:   [ "sign_in" ]
+      # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
+      # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
+      # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
+      # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
+      # sign_in:   [ "sign_in" ]
       x-seal-default-action: deny
     category:
       type: object

--- a/docs/source/key-concepts/introduction.md
+++ b/docs/source/key-concepts/introduction.md
@@ -84,19 +84,19 @@ components:
       type: object
       x-seal-type: verbs
       x-seal-verbs:
-      - inspect:   [ "list", "watch" ]
-      - read:      [ "get", "list", "watch" ]
-      - use:       [ "update", "get", "list", "watch" ]
-      - manage:    [ "create", "delete", "update", "get", "list", "watch" ]
+        inspect:   [ "list", "watch" ]
+        read:      [ "get", "list", "watch" ]
+        use:       [ "update", "get", "list", "watch" ]
+        manage:    [ "create", "delete", "update", "get", "list", "watch" ]
     # example resource types that references global verbs and custom verb
     products.inventory:
       type: object
       x-seal-verbs:
-      - inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
-      - read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
-      - use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
-      - manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      - provision: [ "provision", "deprovision" ]  # non-global permissions
+        inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
+        read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
+        use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
+        manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
+        provision: [ "provision", "deprovision" ]  # non-global permissions
     ...
 ```
 


### PR DESCRIPTION
documentation for verb to permission mappings should have been a map instead of an array per GH-104