### PR TITLE
GH-104: Add parsing/rego support for (non-global) verb-permission mappings

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -4,14 +4,99 @@ default allow = false
 
 default deny = false
 
+base_verbs := {
+	"petstore.order": {
+		"approve": ["approve"],
+		"deliver": ["deliver"],
+		"inspect": [
+			"list",
+			"watch",
+		],
+		"manage": [
+			"create",
+			"delete",
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+		"read": [
+			"get",
+			"list",
+			"watch",
+		],
+		"ship": ["ship"],
+		"use": [
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+	},
+	"petstore.pet": {
+		"buy": ["buy"],
+		"inspect": [
+			"list",
+			"watch",
+		],
+		"manage": [
+			"create",
+			"delete",
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+		"provision": ["provision"],
+		"read": [
+			"get",
+			"list",
+			"watch",
+		],
+		"sell": ["sell"],
+		"use": [
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+	},
+	"petstore.user": {
+		"inspect": [
+			"list",
+			"watch",
+		],
+		"manage": [
+			"create",
+			"delete",
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+		"read": [
+			"get",
+			"list",
+			"watch",
+		],
+		"sign_in": ["sign_in"],
+		"use": [
+			"update",
+			"get",
+			"list",
+			"watch",
+		],
+	},
+}
+
 deny {
-	input.verb == `deliver`
+	seal_list_contains(base_verbs[input.type].deliver, input.verb)
 	re_match(`petstore.order`, input.type)
 	seal_list_contains(seal_subject.groups, `boss`)
 }
 
 deny {
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.order`, input.type)
 
 	some i
@@ -19,7 +104,7 @@ deny {
 }
 
 deny {
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.user`, input.type)
 
 	some i
@@ -27,19 +112,19 @@ deny {
 }
 
 deny {
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.order`, input.type)
 	seal_subject.iss != "context.petstore.swagger.io"
 }
 
 deny {
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.user`, input.type)
 	seal_subject.iss != "context.petstore.swagger.io"
 }
 
 deny {
-	input.verb == `deliver`
+	seal_list_contains(base_verbs[input.type].deliver, input.verb)
 	re_match(`petstore.order`, input.type)
 
 	some i
@@ -48,21 +133,21 @@ deny {
 
 deny {
 	seal_list_contains(seal_subject.groups, `regexp`)
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.*`, input.type)
 	re_match(`@petstore.swagger.io$`, seal_subject.jti)
 }
 
 deny {
 	seal_list_contains(seal_subject.groups, `everyone`)
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.*`, input.type)
 	seal_subject.iss != "petstore.swagger.io"
 }
 
 deny {
 	seal_list_contains(seal_subject.groups, `everyone`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 
 	some i
@@ -72,13 +157,13 @@ deny {
 
 deny {
 	seal_list_contains(seal_subject.groups, `banned`)
-	input.verb == `manage`
+	seal_list_contains(base_verbs[input.type].manage, input.verb)
 	re_match(`petstore.*`, input.type)
 }
 
 deny {
 	seal_list_contains(seal_subject.groups, `managers`)
-	input.verb == `sell`
+	seal_list_contains(base_verbs[input.type].sell, input.verb)
 	re_match(`petstore.pet`, input.type)
 
 	some i
@@ -87,7 +172,7 @@ deny {
 
 deny {
 	seal_list_contains(seal_subject.groups, `fussy`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 	not line13_not1_cnd
 }
@@ -106,7 +191,7 @@ line13_not2_cnd {
 
 allow {
 	seal_list_contains(seal_subject.groups, `fussy`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 	not line14_not1_cnd
 }
@@ -119,7 +204,7 @@ line14_not1_cnd {
 
 deny {
 	seal_list_contains(seal_subject.groups, `everyone`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 
 	some i
@@ -128,37 +213,37 @@ deny {
 
 allow {
 	seal_list_contains(seal_subject.groups, `operators`)
-	input.verb == `use`
+	seal_list_contains(base_verbs[input.type].use, input.verb)
 	re_match(`petstore.*`, input.type)
 }
 
 allow {
 	seal_list_contains(seal_subject.groups, `managers`)
-	input.verb == `manage`
+	seal_list_contains(base_verbs[input.type].manage, input.verb)
 	re_match(`petstore.*`, input.type)
 }
 
 allow {
 	seal_subject.sub == `cto@petstore.swagger.io`
-	input.verb == `manage`
+	seal_list_contains(base_verbs[input.type].manage, input.verb)
 	re_match(`petstore.*`, input.type)
 }
 
 allow {
 	seal_list_contains(seal_subject.groups, `everyone`)
-	input.verb == `inspect`
+	seal_list_contains(base_verbs[input.type].inspect, input.verb)
 	re_match(`petstore.pet`, input.type)
 }
 
 allow {
 	seal_list_contains(seal_subject.groups, `customers`)
-	input.verb == `read`
+	seal_list_contains(base_verbs[input.type].read, input.verb)
 	re_match(`petstore.pet`, input.type)
 }
 
 allow {
 	seal_list_contains(seal_subject.groups, `customers`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 
 	some i
@@ -167,7 +252,7 @@ allow {
 
 allow {
 	seal_list_contains(seal_subject.groups, `breeders_maltese`)
-	input.verb == `buy`
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
 
 	some i

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -1,15 +1,116 @@
 
 package petstore.all
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.order": {
+        "approve": [
+            "approve",
+        ],
+        "deliver": [
+            "deliver",
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+        "read": [
+            "get",
+            "list",
+            "watch",
+        ],
+        "ship": [
+            "ship",
+        ],
+        "use": [
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+    },
+    "petstore.pet": {
+        "buy": [
+            "buy",
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+        "provision": [
+            "provision",
+        ],
+        "read": [
+            "get",
+            "list",
+            "watch",
+        ],
+        "sell": [
+            "sell",
+        ],
+        "use": [
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+    },
+    "petstore.user": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+        "read": [
+            "get",
+            "list",
+            "watch",
+        ],
+        "sign_in": [
+            "sign_in",
+        ],
+        "use": [
+            "update",
+            "get",
+            "list",
+            "watch",
+        ],
+    },
+}
+
 deny {
-    input.verb == `deliver`
+    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
     re_match(`petstore.order`, input.type)
     seal_list_contains(seal_subject.groups, `boss`)
 }
 
 deny {
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.order`, input.type)
 
     some i
@@ -17,7 +118,7 @@ deny {
 }
 
 deny {
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.user`, input.type)
 
     some i
@@ -25,19 +126,19 @@ deny {
 }
 
 deny {
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.order`, input.type)
     seal_subject.iss != "context.petstore.swagger.io"
 }
 
 deny {
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.user`, input.type)
     seal_subject.iss != "context.petstore.swagger.io"
 }
 
 deny {
-    input.verb == `deliver`
+    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
     re_match(`petstore.order`, input.type)
 
     some i
@@ -46,21 +147,21 @@ deny {
 
 deny {
     seal_list_contains(seal_subject.groups, `regexp`)
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.*`, input.type)
     re_match(`@petstore.swagger.io$`, seal_subject.jti)
 }
 
 deny {
     seal_list_contains(seal_subject.groups, `everyone`)
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.*`, input.type)
     seal_subject.iss != "petstore.swagger.io"
 }
 
 deny {
     seal_list_contains(seal_subject.groups, `everyone`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
 
     some i
@@ -70,13 +171,13 @@ deny {
 
 deny {
     seal_list_contains(seal_subject.groups, `banned`)
-    input.verb == `manage`
+    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
     re_match(`petstore.*`, input.type)
 }
 
 deny {
     seal_list_contains(seal_subject.groups, `managers`)
-    input.verb == `sell`
+    seal_list_contains(base_verbs[input.type][`sell`], input.verb)
     re_match(`petstore.pet`, input.type)
 
     some i
@@ -85,7 +186,7 @@ deny {
 
 deny {
     seal_list_contains(seal_subject.groups, `fussy`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
     not line13_not1_cnd
 }
@@ -104,7 +205,7 @@ line13_not2_cnd {
 
 allow {
     seal_list_contains(seal_subject.groups, `fussy`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
     not line14_not1_cnd
 }
@@ -117,7 +218,7 @@ line14_not1_cnd {
 
 deny {
     seal_list_contains(seal_subject.groups, `everyone`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
 
     some i
@@ -126,37 +227,37 @@ deny {
 
 allow {
     seal_list_contains(seal_subject.groups, `operators`)
-    input.verb == `use`
+    seal_list_contains(base_verbs[input.type][`use`], input.verb)
     re_match(`petstore.*`, input.type)
 }
 
 allow {
     seal_list_contains(seal_subject.groups, `managers`)
-    input.verb == `manage`
+    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
     re_match(`petstore.*`, input.type)
 }
 
 allow {
     seal_subject.sub == `cto@petstore.swagger.io`
-    input.verb == `manage`
+    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
     re_match(`petstore.*`, input.type)
 }
 
 allow {
     seal_list_contains(seal_subject.groups, `everyone`)
-    input.verb == `inspect`
+    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
     re_match(`petstore.pet`, input.type)
 }
 
 allow {
     seal_list_contains(seal_subject.groups, `customers`)
-    input.verb == `read`
+    seal_list_contains(base_verbs[input.type][`read`], input.verb)
     re_match(`petstore.pet`, input.type)
 }
 
 allow {
     seal_list_contains(seal_subject.groups, `customers`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
 
     some i
@@ -165,7 +266,7 @@ allow {
 
 allow {
     seal_list_contains(seal_subject.groups, `breeders_maltese`)
-    input.verb == `buy`
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
 
     some i

--- a/docs/source/examples/petstore/petstore.all.swagger
+++ b/docs/source/examples/petstore/petstore.all.swagger
@@ -53,21 +53,18 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - read
-      - use
-      - manage
-      - approve
-      - ship
-      - deliver
       # TODO: GH-104
       # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
       # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
       # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
       # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      # approve:   [ "approve" ]
-      # ship:      [ "ship" ]
-      # deliver:   [ "deliver" ]
+        inspect:   [ "list", "watch" ]
+        read:      [ "get", "list", "watch" ]
+        use:       [ "update", "get", "list", "watch" ]
+        manage:    [ "create", "delete", "update", "get", "list", "watch" ]
+        approve:   [ "approve" ]
+        ship:      [ "ship" ]
+        deliver:   [ "deliver" ]
       x-seal-default-action: deny
     petstore.pet:
       type: object
@@ -75,21 +72,18 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - read
-      - use
-      - manage
-      - provision
-      - buy
-      - sell
       # TODO: GH-104
       # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
       # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
       # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
       # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      # provision: [ "provision" ]
-      # buy:       [ "buy" ]
-      # sell:      [ "sell" ]
+        inspect:   [ "list", "watch" ]
+        read:      [ "get", "list", "watch" ]
+        use:       [ "update", "get", "list", "watch" ]
+        manage:    [ "create", "delete", "update", "get", "list", "watch" ]
+        provision: [ "provision" ]
+        buy:       [ "buy" ]
+        sell:      [ "sell" ]
       x-seal-default-action: deny
       properties:
         id:
@@ -145,17 +139,16 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - read
-      - use
-      - manage
-      - sign_in
       # TODO: GH-104
       # inspect:   [ "#/components/schemas/verbs/x-seal-verbs/inspect" ]
       # read:      [ "#/components/schemas/verbs/x-seal-verbs/read" ]
       # use:       [ "#/components/schemas/verbs/x-seal-verbs/use" ]
       # manage:    [ "#/components/schemas/verbs/x-seal-verbs/manage" ]
-      # sign_in:   [ "sign_in" ]
+        inspect:   [ "list", "watch" ]
+        read:      [ "get", "list", "watch" ]
+        use:       [ "update", "get", "list", "watch" ]
+        manage:    [ "create", "delete", "update", "get", "list", "watch" ]
+        sign_in:   [ "sign_in" ]
       x-seal-default-action: deny
     category:
       type: object

--- a/docs/source/examples/petstore/petstore.all.test.rego
+++ b/docs/source/examples/petstore/petstore.all.test.rego
@@ -35,7 +35,7 @@ test_in_negative {
 test_regexp {
 	in := {
 		"type": "petstore.pet",
-		"verb": "use",
+		"verb": "get",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"jti": "@petstore.swagger.io",
@@ -50,7 +50,7 @@ test_regexp {
 test_regexp_negative {
 	in := {
 		"type": "petstore.pet",
-		"verb": "use",
+		"verb": "watch",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"jti": "just test regexp params",
@@ -166,7 +166,7 @@ test_use_tags_negative_missing_endangered_tag {
 test_use_petstore_jwt {
 	in := {
 		"type": "petstore.pet",
-		"verb": "use",
+		"verb": "list",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -180,7 +180,7 @@ test_use_petstore_jwt {
 test_use_petstore_jwt_negative {
 	in := {
 		"type": "petstore.pet",
-		"verb": "use",
+		"verb": "update",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -195,7 +195,7 @@ test_use_petstore_jwt_negative {
 test_banned_deny {
 	in := {
 		"type": "petstore.pet",
-		"verb": "manage",
+		"verb": "create",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -209,7 +209,7 @@ test_banned_deny {
 test_banned_deny_negative {
 	in := {
 		"type": "petstore.pet",
-		"verb": "manage",
+		"verb": "delete",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -224,7 +224,7 @@ test_banned_deny_negative {
 test_inspect {
 	in := {
 		"type": "petstore.pet",
-		"verb": "inspect",
+		"verb": "list",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "inspector-gadget@disney.com",
@@ -238,7 +238,7 @@ test_inspect {
 test_inspect_negative {
 	in := {
 		"type": "petstore.pet",
-		"verb": "read",
+		"verb": "get",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "inspector-gadget@disney.com",
@@ -253,7 +253,7 @@ test_inspect_negative {
 test_read {
 	in := {
 		"type": "petstore.pet",
-		"verb": "read",
+		"verb": "watch",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -267,7 +267,7 @@ test_read {
 test_read_negative {
 	in := {
 		"type": "petstore.pet",
-		"verb": "use",
+		"verb": "get",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "wiley-e-coyote@acme.com",
@@ -275,14 +275,14 @@ test_read_negative {
 		}),
 	}
 
-	not allow with input as in
+	deny with input as in
 }
 
 # allow subject user cto@petstore.swagger.io to manage petstore.pet;
 test_manage_cto {
 	in := {
 		"type": "petstore.pet",
-		"verb": "manage",
+		"verb": "watch",
 		"jwt": sealtest_jwt_encode_sign({
 			"iss": "not_petstore.swagger.io",
 			"sub": "cto@petstore.swagger.io",

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/infobloxopen/seal/pkg/ast"
 	"github.com/infobloxopen/seal/pkg/compiler/error"
+	"github.com/infobloxopen/seal/pkg/types"
 )
 
 // compiler defines the interface for the language specific compiler backends
 type Compiler interface {
 	// Compile compiles a set of policies into a string
-	Compile(pkgname string, pols *ast.Policies) (string, error)
+	Compile(pkgname string, pols *ast.Policies, swaggerTypes []types.Type) (string, error)
 }
 
 // New creates a new compiler

--- a/pkg/compiler/policy_compiler.go
+++ b/pkg/compiler/policy_compiler.go
@@ -86,7 +86,7 @@ func (rc *PolicyCompiler) Compile(packageName string, policyString string) (stri
 	}
 
 	// compile policies from AST
-	content, err := rc.cmplr.Compile(packageName, pols)
+	content, err := rc.cmplr.Compile(packageName, pols, rc.swaggerTypes)
 	if err != nil {
 		return "", fmt.Errorf("could not compile package %s: %s\n", packageName, err)
 	}

--- a/pkg/compiler/test/compiler_test.go
+++ b/pkg/compiler/test/compiler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/infobloxopen/seal/pkg/compiler"
 	"github.com/infobloxopen/seal/pkg/compiler/error"
 	"github.com/infobloxopen/seal/pkg/compiler/rego"
+	"github.com/infobloxopen/seal/pkg/types"
 )
 
 func TestCompiler(t *testing.T) {
@@ -47,7 +48,8 @@ func TestCompiler(t *testing.T) {
 			continue
 		}
 
-		actual, err := c.Compile(tst.pkg, tst.pols)
+		var emptySwaggerTypes []types.Type
+		actual, err := c.Compile(tst.pkg, tst.pols, emptySwaggerTypes)
 		if tst.err2 == nil && err != nil || tst.err2 != nil && err == nil {
 			t.Fatalf("expected error state not returned for tst #%d tst:%s.\n  expected: %s  actual: %s",
 				idx+1, tst.name, tst.err2, err)

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -92,11 +92,48 @@ expected next token to be to, got ; instead`),
 			policyString:   `allow subject group everyone to inspect products.inventory;`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
 }
 ` + compiler_rego.CompiledRegoHelpers,
@@ -107,14 +144,51 @@ allow {
 			policyString:   `allow subject group everyone to inspect products.inventory where ctx.id=="bar" and ctx.name=="foo";`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
 
-	some i
+    some i
     input.ctx[i]["id"] == "bar"
     input.ctx[i]["name"] == "foo"
 }
@@ -126,24 +200,61 @@ allow {
 			policyString:   `allow subject group everyone to inspect products.inventory where not ctx.neutered and not ctx.potty_trained;`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
     not line1_not1_cnd
 }
 
 line1_not1_cnd {
-	some i
+    some i
     input.ctx[i]["neutered"]
 
     not line1_not2_cnd
 }
 
 line1_not2_cnd {
-	some i
+    some i
     input.ctx[i]["potty_trained"]
 }
 ` + compiler_rego.CompiledRegoHelpers,
@@ -154,24 +265,61 @@ line1_not2_cnd {
 			policyString:   `allow subject group everyone to inspect products.inventory where not ctx.id == "bar" and not ctx.name == "foo";`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
     not line1_not1_cnd
 }
 
 line1_not1_cnd {
-	some i
+    some i
     input.ctx[i]["id"] == "bar"
 
     not line1_not2_cnd
 }
 
 line1_not2_cnd {
-	some i
+    some i
     input.ctx[i]["name"] == "foo"
 }
 ` + compiler_rego.CompiledRegoHelpers,
@@ -182,17 +330,54 @@ line1_not2_cnd {
 			policyString:   `allow subject group everyone to inspect products.inventory where not (ctx.id == "bar" and ctx.name == "foo");`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
     not line1_not1_cnd
 }
 
 line1_not1_cnd {
-	some i
+    some i
     input.ctx[i]["id"] == "bar"
     input.ctx[i]["name"] == "foo"
 }
@@ -204,11 +389,48 @@ line1_not1_cnd {
 			policyString:   `allow subject group everyone to inspect products.inventory where not ( (not (ctx.id == "bar" and ctx.name == "foo")) and (not (ctx.neutered and ctx.potty_trained)) ));`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('products.inventory', input.type)
     not line1_not3_cnd
 }
@@ -218,7 +440,7 @@ line1_not3_cnd {
 }
 
 line1_not1_cnd {
-	some i
+    some i
     input.ctx[i]["id"] == "bar"
     input.ctx[i]["name"] == "foo"
 
@@ -226,7 +448,7 @@ line1_not1_cnd {
 }
 
 line1_not2_cnd {
-	some i
+    some i
     input.ctx[i]["neutered"]
     input.ctx[i]["potty_trained"]
 }
@@ -243,29 +465,66 @@ line1_not2_cnd {
 				`,
 			result: `
 package products.inventory
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
-	re_match('products.inventory', input.type)
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
+    re_match('products.inventory', input.type)
 
-	some i
+    some i
     input.ctx[i]["id"] == "bar"
 }
 
 allow {
     seal_list_contains(seal_subject.groups, 'everyone')
-    input.verb == 'inspect'
-	re_match('products.inventory', input.type)
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
+    re_match('products.inventory', input.type)
 
-	some i
+    some i
     input.ctx[i]["id"] != "bar"
 }
 
 allow {
     seal_list_contains(seal_subject.groups, 'nobody')
-    input.verb == 'use'
+    seal_list_contains(base_verbs[input.type]['use'], input.verb)
     re_match('products.inventory', input.type)
 }
 ` + compiler_rego.CompiledRegoHelpers,
@@ -273,20 +532,57 @@ allow {
 		"company.personnel": {
 			packageName:    "company.personnel",
 			swaggerContent: []string{"company"},
-			policyString:   "allow subject group manager to operate company.*;\nallow subject group users to list company.personnel;",
+			policyString:   "allow subject group manager to operate company.*;\nallow subject group users to inspect company.personnel;",
 			result: `
 package company.personnel
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
     seal_list_contains(seal_subject.groups, 'manager')
-    input.verb == 'operate'
+    seal_list_contains(base_verbs[input.type]['operate'], input.verb)
     re_match('company.*', input.type)
 }
 
 allow {
     seal_list_contains(seal_subject.groups, 'users')
-    input.verb == 'list'
+    seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
     re_match('company.personnel', input.type)
 }
 ` + compiler_rego.CompiledRegoHelpers,
@@ -297,11 +593,30 @@ allow {
 			policyString:   "allow subject group patissiers to manage petstore.* where ctx.tags[\"department\"] == \"bakery\"",
 			result: `
 package petstore
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.pet": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
 	seal_list_contains(seal_subject.groups, 'patissiers')
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.*', input.type)
 
 	some i
@@ -315,11 +630,34 @@ allow {
 			policyString:   "allow subject group patissiers to manage petstore.* where ctx.name =~ \"someValue\"",
 			result: `
 package petstore
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
 	seal_list_contains(seal_subject.groups, 'patissiers')
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.*', input.type)
 
 	some i
@@ -333,10 +671,33 @@ allow {
 			policyString:   "allow to manage petstore.* where ctx.name =~ \"someValue\"",
 			result: `
 package petstore
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.*', input.type)
 
 	some i
@@ -350,11 +711,33 @@ allow {
 			policyString:   `context { where ctx.name=="name"; } to use { allow petstore.*; }`,
 			result: `
 package petstore
+
 default allow = false
 default deny = false
 
+base_verbs := {
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
-	input.verb == 'use'
+	seal_list_contains(base_verbs[input.type]['use'], input.verb)
 	re_match('petstore.*', input.type)
 
 	some i
@@ -368,17 +751,71 @@ allow {
 			policyString:   `context { where subject.sub=="name"; } to use { allow petstore.*; deny products.*;}`,
 			result: `
 package petstore
+
 default allow = false
 default deny = false
 
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
-	input.verb == 'use'
+	seal_list_contains(base_verbs[input.type]['use'], input.verb)
 	re_match('petstore.*', input.type)
 	seal_subject.sub == "name"
 }
 
 deny {
-	input.verb == 'use'
+	seal_list_contains(base_verbs[input.type]['use'], input.verb)
 	re_match('products.*', input.type)
 	seal_subject.sub == "name"
 }
@@ -396,28 +833,82 @@ context {
 }`,
 			result: `
 package petstore
+
 default allow = false
 default deny = false
 
+base_verbs := {
+    "company.personnel": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "operate": [
+            "turn-on",
+            "turn-off",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+    "products.inventory": {
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 allow {
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.*', input.type)
 }
 
 allow {
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.*', input.type)
 	seal_subject.sub == "name"
 }
 
 deny {
-	input.verb == 'inspect'
+	seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
 	re_match('products.*', input.type)
 	seal_subject.sub == "name2"
 }
 
 deny {
-	input.verb == 'inspect'
+	seal_list_contains(base_verbs[input.type]['inspect'], input.verb)
 	re_match('products.*', input.type)
 	seal_subject.sub == "name"
 }
@@ -429,10 +920,33 @@ deny {
 			policyString:   `deny to manage petstore.pet where "banned" in subject.sub;`,
 			result: `
 package petstore
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 deny {
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.pet', input.type)
 	seal_list_contains(seal_subject.sub, 'banned')
 }
@@ -444,10 +958,33 @@ deny {
 			policyString:   `deny to manage petstore.pet where not "banned" in subject.sub;`,
 			result: `
 package petstore
+
 default allow = false
 default deny = false
+
+base_verbs := {
+    "petstore.pet": {
+        "emptyvrb1": [
+        ],
+        "emptyvrb2": [
+        ],
+        "inspect": [
+            "list",
+            "watch",
+        ],
+        "manage": [
+            "create",
+            "delete",
+        ],
+        "use": [
+            "update",
+            "get",
+        ],
+    },
+}
+
 deny {
-	input.verb == 'manage'
+	seal_list_contains(base_verbs[input.type]['manage'], input.verb)
 	re_match('petstore.pet', input.type)
 	not line1_not1_cnd
 }
@@ -664,9 +1201,11 @@ components:
 			- allow
 			- deny
 			x-seal-verbs:
-			- inspect
-			- use
-			- manage
+                          inspect:   [ "list", "watch" ]
+                          use:       [ "update", "get" ]
+                          manage:    [ "create", "delete" ]
+                          emptyvrb1: []
+                          emptyvrb2:
 			x-seal-default-action: deny 
 `,
 	"sw2": `
@@ -692,9 +1231,9 @@ components:
 			- allow
 			- deny
 			x-seal-verbs:
-			- inspect
-			- use
-			- manage
+                          inspect:   [ "list", "watch" ]
+                          use:       [ "update", "get" ]
+                          manage:    [ "create", "delete" ]
 			x-seal-default-action: deny 
 `,
 	"tags": `
@@ -731,9 +1270,9 @@ components:
 			- allow
 			- deny
 			x-seal-verbs:
-			- inspect
-			- use
-			- manage
+                          inspect:   [ "list", "watch" ]
+                          use:       [ "update", "get" ]
+                          manage:    [ "create", "delete" ]
 			x-seal-default-action: deny 
 `,
 	"company": `
@@ -752,9 +1291,9 @@ components:
 			- allow
 			- deny
 			x-seal-verbs:
-			- inspect
-			- use
-			- manage
+                          inspect:   [ "list", "watch" ]
+                          use:       [ "update", "get" ]
+                          manage:    [ "create", "delete" ]
 			x-seal-default-action: deny
 			properties:
 				id:
@@ -771,10 +1310,10 @@ components:
 			- allow
 			- deny
 			x-seal-verbs:
-			- inspect
-			- list
-			- manage
-			- operate
+                          inspect:   [ "list", "watch" ]
+                          use:       [ "update", "get" ]
+                          manage:    [ "create", "delete" ]
+                          operate:   [ "turn-on", "turn-off" ]
 			x-seal-default-action: deny
 			properties:
 				id:

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -27,11 +27,11 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - read
-      - use
-      - manage
-      - buy
+        inspect:
+        read:
+        use:
+        manage:
+        buy:
       x-seal-default-action: deny
       properties:
         id:
@@ -51,11 +51,11 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - read
-      - use
-      - manage
-      - sign_in
+        inspect:
+        read:
+        use:
+        manage:
+        sign_in:
       x-seal-default-action: deny
       properties:
         id:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -60,6 +60,10 @@ func (s simpleVerb) GetName() string {
 func (s simpleVerb) String() string {
 	return string(s)
 }
+func (s simpleVerb) GetBaseVerbs() types.BaseVerbs {
+	var emptyBaseVerbs types.BaseVerbs
+        return emptyBaseVerbs
+}
 
 type simpleAction string
 

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -48,8 +48,8 @@ components:
       - allow
       - deny
       x-seal-verbs:
-      - inspect
-      - use
-      - manage
+        inspect:
+        use:
+        manage:
       x-seal-default-action: deny 
 `)


### PR DESCRIPTION
```
$ make test
?       github.com/infobloxopen/seal    [no test files]
?       github.com/infobloxopen/seal/cmd        [no test files]
?       github.com/infobloxopen/seal/pkg/ast    [no test files]
?       github.com/infobloxopen/seal/pkg/compiler       [no test files]
?       github.com/infobloxopen/seal/pkg/compiler/error [no test files]
=== RUN   TestCompile
    rego_test.go:174: validate policy: allow subject group foo to manage petstore.pet;
    rego_test.go:175: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_list_contains(seal_subject.groups, `foo`)
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
    rego_test.go:174: validate policy: allow subject user foo to manage petstore.pet;
    rego_test.go:175: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_subject.sub == `foo`
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
--- PASS: TestCompile (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/rego  (cached)
=== RUN   TestCompiler
--- PASS: TestCompiler (0.00s)
=== RUN   TestLanguages
    compiler_test.go:86: validate list of languages - supported languages: []string{"rego"}
--- PASS: TestLanguages (0.00s)
=== RUN   TestBackend
=== RUN   TestBackend/company.personnel
=== RUN   TestBackend/no-swagger-actions
=== RUN   TestBackend/statement-with-and
=== RUN   TestBackend/precedence-with-not
=== RUN   TestBackend/multiple-statements
=== RUN   TestBackend/statement-with-not
=== RUN   TestBackend/grouping-with-not-and-parens
=== RUN   TestBackend/tags
=== RUN   TestBackend/matches
=== RUN   TestBackend/blank-swagger
=== RUN   TestBackend/missing-verb-errors
=== RUN   TestBackend/missing-resource-errors
=== RUN   TestBackend/simplest-statement-with-subject
=== RUN   TestBackend/blank-subject
=== RUN   TestBackend/context-nested
=== RUN   TestBackend/in-operator
=== RUN   TestBackend/context
=== RUN   TestBackend/context-2
=== RUN   TestBackend/missing-to-errors
=== RUN   TestBackend/invalid-resource-format-without-using-family.type-errors
=== RUN   TestBackend/invalid-resource-not-registered
=== RUN   TestBackend/grouping-with-parens
=== RUN   TestBackend/not-in-operator
--- PASS: TestBackend (0.04s)
    --- PASS: TestBackend/company.personnel (0.00s)
    --- PASS: TestBackend/no-swagger-actions (0.00s)
    --- PASS: TestBackend/statement-with-and (0.00s)
    --- PASS: TestBackend/precedence-with-not (0.00s)
    --- PASS: TestBackend/multiple-statements (0.00s)
    --- PASS: TestBackend/statement-with-not (0.00s)
    --- PASS: TestBackend/grouping-with-not-and-parens (0.00s)
    --- PASS: TestBackend/tags (0.00s)
    --- PASS: TestBackend/matches (0.00s)
    --- PASS: TestBackend/blank-swagger (0.00s)
    --- PASS: TestBackend/missing-verb-errors (0.00s)
    --- PASS: TestBackend/missing-resource-errors (0.00s)
    --- PASS: TestBackend/simplest-statement-with-subject (0.00s)
    --- PASS: TestBackend/blank-subject (0.00s)
    --- PASS: TestBackend/context-nested (0.00s)
    --- PASS: TestBackend/in-operator (0.00s)
    --- PASS: TestBackend/context (0.00s)
    --- PASS: TestBackend/context-2 (0.00s)
    --- PASS: TestBackend/missing-to-errors (0.00s)
    --- PASS: TestBackend/invalid-resource-format-without-using-family.type-errors (0.00s)
    --- PASS: TestBackend/invalid-resource-not-registered (0.00s)
    --- PASS: TestBackend/grouping-with-parens (0.00s)
    --- PASS: TestBackend/not-in-operator (0.00s)
=== RUN   TestManySwaggers
=== RUN   TestManySwaggers/empty
=== RUN   TestManySwaggers/global-sw1-sw2
=== RUN   TestManySwaggers/global-sw2-sw1
=== RUN   TestManySwaggers/sw1
=== RUN   TestManySwaggers/sw2
=== RUN   TestManySwaggers/global
--- PASS: TestManySwaggers (0.01s)
    --- PASS: TestManySwaggers/empty (0.00s)
    --- PASS: TestManySwaggers/global-sw1-sw2 (0.00s)
    --- PASS: TestManySwaggers/global-sw2-sw1 (0.00s)
    --- PASS: TestManySwaggers/sw1 (0.00s)
    --- PASS: TestManySwaggers/sw2 (0.00s)
    --- PASS: TestManySwaggers/global (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/test  (cached)
=== RUN   TestNextToken
--- PASS: TestNextToken (0.00s)
=== RUN   TestContextToken
--- PASS: TestContextToken (0.00s)
=== RUN   TestNextTokenComment
--- PASS: TestNextTokenComment (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/lexer  (cached)
=== RUN   TestWhereClause
=== RUN   TestWhereClause/simple_user
=== RUN   TestWhereClause/simple_group
=== RUN   TestWhereClause/simple_where_clause_compare_equal
=== RUN   TestWhereClause/simple_where_clause_compare_not_equal
=== RUN   TestWhereClause/simple_where_clause_compare_int
=== RUN   TestWhereClause/simple_where_clause_compare_bool
=== RUN   TestWhereClause/single_where_clause_and
=== RUN   TestWhereClause/left_associative_where_clause_and
=== RUN   TestWhereClause/where_clause_grouped_conditions
=== RUN   TestWhereClause/where_clause_multiple_grouped_conditions
--- PASS: TestWhereClause (0.00s)
    --- PASS: TestWhereClause/simple_user (0.00s)
    --- PASS: TestWhereClause/simple_group (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_not_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_int (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_bool (0.00s)
    --- PASS: TestWhereClause/single_where_clause_and (0.00s)
    --- PASS: TestWhereClause/left_associative_where_clause_and (0.00s)
    --- PASS: TestWhereClause/where_clause_grouped_conditions (0.00s)
    --- PASS: TestWhereClause/where_clause_multiple_grouped_conditions (0.00s)
=== RUN   TestLetStatements
--- PASS: TestLetStatements (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/parser (cached)
=== RUN   TestLookupOperator
=== RUN   TestLookupOperator/invalid_empty
=== RUN   TestLookupOperator/equal_to
=== RUN   TestLookupOperator/not_equal
=== RUN   TestLookupOperator/less_than
=== RUN   TestLookupOperator/greater_than
=== RUN   TestLookupOperator/less_than_or_equal_to
=== RUN   TestLookupOperator/greater_than_or_equal_to
=== RUN   TestLookupOperator/not
=== RUN   TestLookupOperator/and
=== RUN   TestLookupOperator/or
=== RUN   TestLookupOperator/matches
--- PASS: TestLookupOperator (0.00s)
    --- PASS: TestLookupOperator/invalid_empty (0.00s)
    --- PASS: TestLookupOperator/equal_to (0.00s)
    --- PASS: TestLookupOperator/not_equal (0.00s)
    --- PASS: TestLookupOperator/less_than (0.00s)
    --- PASS: TestLookupOperator/greater_than (0.00s)
    --- PASS: TestLookupOperator/less_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/greater_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/not (0.00s)
    --- PASS: TestLookupOperator/and (0.00s)
    --- PASS: TestLookupOperator/or (0.00s)
    --- PASS: TestLookupOperator/matches (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/token  (cached)
=== RUN   TestIsNilInterface
--- PASS: TestIsNilInterface (0.00s)
=== RUN   TestNewTypeFromOpenAPIv3
    types_test.go:17: got type: petstore.pet
    types_test.go:19: got action: &types.swaggerAction{name:"allow", schema:(*openapi3.SchemaRef)(0xc00000ef80)}
    types_test.go:23:     TODO: get type schema for action
    types_test.go:19: got action: &types.swaggerAction{name:"deny", schema:(*openapi3.SchemaRef)(nil)}
    types_test.go:23:     TODO: get type schema for action
--- PASS: TestNewTypeFromOpenAPIv3 (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/types  (cached)
```

```
$ make demo
./seal compile \
        -s docs/source/examples/petstore/petstore.jwt.swagger \
        -s docs/source/examples/petstore/petstore.tags.swagger \
        -s docs/source/examples/petstore/petstore.all.swagger \
        -f docs/source/examples/petstore/petstore.all.seal \
        > docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] logging level                                 logging.level=info
cat docs/source/examples/petstore/petstore.all.rego.compiled

package petstore.all

default allow = false
default deny = false

base_verbs := {
    "petstore.order": {
        "approve": [
            "approve",
        ],
        "deliver": [
            "deliver",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "ship": [
            "ship",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.pet": {
        "buy": [
            "buy",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "provision": [
            "provision",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sell": [
            "sell",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.user": {
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sign_in": [
            "sign_in",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_list_contains(seal_subject.groups, `boss`)
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["status"] == "delivered"
}

deny {
    seal_list_contains(seal_subject.groups, `regexp`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    re_match(`@petstore.swagger.io$`, seal_subject.jti)
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    seal_subject.iss != "petstore.swagger.io"
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["age"] <= 2
    input.ctx[i]["name"] == "specificPetName"
}

deny {
    seal_list_contains(seal_subject.groups, `banned`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

deny {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`sell`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] != "available"
}

deny {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line13_not1_cnd
}

line13_not1_cnd {
    some i
    input.ctx[i]["neutered"]

    not line13_not2_cnd
}

line13_not2_cnd {
    some i
    input.ctx[i]["potty_trained"]
}

allow {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line14_not1_cnd
}

line14_not1_cnd {
    some i
    input.ctx[i]["neutered"]
    input.ctx[i]["potty_trained"]
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["tags"]["endangered"] == "true"
}

allow {
    seal_list_contains(seal_subject.groups, `operators`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_subject.sub == `cto@petstore.swagger.io`
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`read`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "available"
}

allow {
    seal_list_contains(seal_subject.groups, `breeders_maltese`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "reserved"
    input.ctx[i]["breed"] == "maltese"
}

# rego functions defined by seal

# Helper to get the token payload.
seal_subject = payload {
    [header, payload, signature] := io.jwt.decode(input.jwt)
}

# seal_list_contains returns true if elem exists in list
seal_list_contains(list, elem) {
    list[_] = elem
}

cp docs/source/examples/petstore/petstore.all.rego.compiled docs/source/examples/petstore/petstore.all.rego
# beware that check-rego.sh reformats the compiled rego files...
./docs/source/examples/check-rego.sh docs/source/examples/petstore
+ IMAGE=openpolicyagent/opa:latest
+ [[ -z docs/source/examples/petstore ]]
+ [[ ! -d docs/source/examples/petstore ]]
++ cd docs/source/examples/petstore
++ /bin/pwd
+ TOP=/home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ cd /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ docker run -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest fmt -w .
+ case "$(basename $0)" in
++ basename ./docs/source/examples/check-rego.sh
+ docker run --rm -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest test -v petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego petstore.all.mock.json
data.petstore.all.test_in: PASS (1.546291ms)
data.petstore.all.test_in_negative: PASS (992.57µs)
data.petstore.all.test_regexp: PASS (1.125791ms)
data.petstore.all.test_regexp_negative: PASS (942.648µs)
data.petstore.all.test_ctx_usage_multiply: PASS (986.675µs)
data.petstore.all.test_ctx_usage_negative_multi_ctx: PASS (936.885µs)
data.petstore.all.test_ctx_usage_negative: PASS (891.593µs)
data.petstore.all.test_use_tags: PASS (1.79849ms)
data.petstore.all.test_use_tags_negative: PASS (1.359099ms)
data.petstore.all.test_use_tags_negative_missing_endangered_tag: PASS (1.246814ms)
data.petstore.all.test_use_petstore_jwt: PASS (1.543026ms)
data.petstore.all.test_use_petstore_jwt_negative: PASS (1.427256ms)
data.petstore.all.test_banned_deny: PASS (1.433996ms)
data.petstore.all.test_banned_deny_negative: PASS (1.231338ms)
data.petstore.all.test_inspect: PASS (911.069µs)
data.petstore.all.test_inspect_negative: PASS (1.754692ms)
data.petstore.all.test_read: PASS (895.465µs)
data.petstore.all.test_read_negative: PASS (1.02261ms)
data.petstore.all.test_manage_cto: PASS (1.152987ms)
data.petstore.all.test_blank_subject: PASS (1.679609ms)
data.petstore.all.test_bench_deny_in_map_species: PASS (334.677µs)
data.petstore.all.test_bench_deny_in_map_species_2nd: PASS (258.984µs)
data.petstore.all.test_bench_deny_in_map_species_negative: PASS (181.922µs)
data.petstore.all.test_bench_deny_in_map_species_negative_2nd: PASS (154.054µs)
--------------------------------------------------------------------------------
PASS: 24/24
+ git diff --exit-code petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests
```

