### PR TITLE
Change compiled rego obligations structure

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -292,11 +292,10 @@ line15_not1_cnd {
 	input.ctx[i].neutered
 }
 
-obligations := [
-	`(ctx.marketplace != "amazon")`,
-	`(ctx.occupation != "unemployed")`,
-	`(ctx.salary > 200000)`,
-]
+obligations := {
+	`stmt19`: [`(ctx.marketplace != "amazon")`],
+	`stmt20`: [`((ctx.occupation != "unemployed") and (ctx.salary > 200000))`],
+}
 
 # rego functions defined by seal
 

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -306,11 +306,10 @@ line15_not1_cnd {
     input.ctx[i]["neutered"]
 }
 
-obligations := [
-    `(ctx.marketplace != "amazon")`,
-    `(ctx.occupation != "unemployed")`,
-    `(ctx.salary > 200000)`,
-]
+obligations := {
+    `stmt19`: [ `(ctx.marketplace != "amazon")` ],
+    `stmt20`: [ `((ctx.occupation != "unemployed") and (ctx.salary > 200000))` ],
+}
 
 # rego functions defined by seal
 

--- a/pkg/compiler/error/errors.go
+++ b/pkg/compiler/error/errors.go
@@ -7,6 +7,7 @@ import (
 
 // Errors ...
 var (
+	ErrInternal           = errors.New("internal error")
 	ErrEmptyLanguage      = errors.New("invalid empty language")
 	ErrEmptyPolicies      = errors.New("invalid empty policies")
 	ErrEmptySubject       = errors.New("invalid empty subject")

--- a/pkg/compiler/rego/rego_test.go
+++ b/pkg/compiler/rego/rego_test.go
@@ -111,8 +111,8 @@ allow {
     re_match(` + "`petstore.pet`" + `, input.type)
 }
 
-obligations := [
-]` + "\n" + CompiledRegoHelpers,
+obligations := {
+}` + "\n" + CompiledRegoHelpers,
 		},
 		{
 			name: "validate policy: allow subject user foo to manage petstore.pet;",
@@ -154,8 +154,8 @@ allow {
     re_match(` + "`petstore.pet`" + `, input.type)
 }
 
-obligations := [
-]` + "\n" + CompiledRegoHelpers,
+obligations := {
+}` + "\n" + CompiledRegoHelpers,
 		},
 	}
 

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -172,8 +172,8 @@ allow {
     re_match('products.inventory', input.type)
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"statement-with-and": {
@@ -231,8 +231,8 @@ allow {
     input.ctx[i]["name"] == "foo"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"statement-with-not": {
@@ -295,8 +295,8 @@ line1_not1_cnd {
     input.ctx[i]["neutered"]
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"precedence-with-not": {
@@ -362,8 +362,8 @@ line1_not2_cnd {
     input.ctx[i]["name"] == "foo"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"grouping-with-parens": {
@@ -424,8 +424,8 @@ line1_not1_cnd {
     input.ctx[i]["name"] == "foo"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"grouping-with-not-and-parens": {
@@ -497,8 +497,8 @@ line1_not3_cnd {
     not line1_not2_cnd
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"multiple-statements": {
@@ -575,8 +575,8 @@ allow {
     re_match('products.inventory', input.type)
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"company.personnel": {
@@ -636,8 +636,8 @@ allow {
     re_match('company.personnel', input.type)
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"tags": {
@@ -676,8 +676,8 @@ allow {
 	input.ctx[i]["tags"]["department"] == "bakery"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"matches": {
@@ -720,8 +720,8 @@ allow {
 	re_match('someValue', input.ctx[i]["name"])
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"blank-subject": {
@@ -763,8 +763,8 @@ allow {
 	re_match('someValue', input.ctx[i]["name"])
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"context": {
@@ -806,8 +806,8 @@ allow {
 	input.ctx[i]["name"] == "name"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"context-2": {
@@ -885,8 +885,8 @@ deny {
 	seal_subject.sub == "name"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"context-nested": {
@@ -981,8 +981,8 @@ deny {
 	seal_subject.sub == "name"
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"in-operator": {
@@ -1022,8 +1022,8 @@ deny {
 	seal_list_contains(seal_subject.sub, 'banned')
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"not-in-operator": {
@@ -1067,8 +1067,8 @@ line1_not1_cnd {
 	seal_list_contains(seal_subject.sub, 'banned')
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"obligations-simple": {
@@ -1125,9 +1125,9 @@ allow {
 	input.ctx[i]["tags"]["age"] == 101
 }
 
-obligations := [
-	'(ctx.color != "blue")',
-]
+obligations := {
+	'stmt0': [ '(ctx.color != "blue")' ],
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"obligations-wildcard": {
@@ -1185,8 +1185,8 @@ allow {
 	input.ctx[i]["tags"]["age"] == 101
 }
 
-obligations := [
-]
+obligations := {
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"obligations-context": {
@@ -1246,9 +1246,9 @@ allow {
 	input.ctx[i]["tags"]["age"] == 101
 }
 
-obligations := [
-	'(not(not(ctx.color =~ "blue")))',
-]
+obligations := {
+	'stmt0': [ '(not(not(ctx.color =~ "blue")))' ],
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"obligations-multi-oblig-in-single-stmt": {
@@ -1305,10 +1305,9 @@ allow {
 	input.ctx[i]["tags"]["age"] == 101
 }
 
-obligations := [
-	'(ctx.color != "blue")',
-	'("100ft" == ctx.height)',
-]
+obligations := {
+	'stmt0': [ '((ctx.color != "blue") and ("100ft" == ctx.height))' ],
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 		"obligations-multi-stmt-with-oblig": {
@@ -1378,12 +1377,10 @@ allow {
 	input.ctx[i]["tags"]["age"] == 101
 }
 
-obligations := [
-	'(ctx.color != "blue")',
-	'("123ft" == ctx.height)',
-	'(ctx.shape != "circle")',
-	'("456lb" == ctx.weight)',
-]
+obligations := {
+	'stmt0': [ '((ctx.color != "blue") and ("123ft" == ctx.height))' ],
+	'stmt1': [ '((ctx.shape != "circle") and ("456lb" == ctx.weight))' ],
+}
 ` + compiler_rego.CompiledRegoHelpers,
 		},
 	}


### PR DESCRIPTION
```
$ make test
?       github.com/infobloxopen/seal    [no test files]
?       github.com/infobloxopen/seal/cmd        [no test files]
?       github.com/infobloxopen/seal/pkg/ast    [no test files]
?       github.com/infobloxopen/seal/pkg/compiler       [no test files]
?       github.com/infobloxopen/seal/pkg/compiler/error [no test files]
=== RUN   TestCompile
    rego_test.go:180: validate policy: allow subject group foo to manage petstore.pet;
    rego_test.go:181: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_list_contains(seal_subject.groups, `foo`)
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        obligations := {
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
    rego_test.go:180: validate policy: allow subject user foo to manage petstore.pet;
    rego_test.go:181: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_subject.sub == `foo`
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        obligations := {
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
--- PASS: TestCompile (0.00s)
=== RUN   TestCleanupSomeI
--- PASS: TestCleanupSomeI (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/rego  (cached)
=== RUN   TestCompiler
--- PASS: TestCompiler (0.00s)
=== RUN   TestLanguages
    compiler_test.go:86: validate list of languages - supported languages: []string{"rego"}
--- PASS: TestLanguages (0.00s)
=== RUN   TestBackend
=== RUN   TestBackend/context-2
=== RUN   TestBackend/support-for-or-operator-simple
=== RUN   TestBackend/statement-with-and
=== RUN   TestBackend/multiple-statements
=== RUN   TestBackend/no-swagger-actions
=== RUN   TestBackend/missing-resource-errors
=== RUN   TestBackend/invalid-resource-not-registered
=== RUN   TestBackend/invalid-nonwildcarded-resource-property
=== RUN   TestBackend/invalid-nonwildcarded-resource-property-with-subject
=== RUN   TestBackend/blank-subject
=== RUN   TestBackend/context
=== RUN   TestBackend/missing-to-errors
=== RUN   TestBackend/invalid-resource-format-without-using-family.type-errors
=== RUN   TestBackend/precedence-with-not
=== RUN   TestBackend/obligations-wildcard
=== RUN   TestBackend/obligations-multi-oblig-in-single-stmt
=== RUN   TestBackend/simplest-statement-with-subject
=== RUN   TestBackend/obligations-context
=== RUN   TestBackend/missing-verb-errors
=== RUN   TestBackend/context-nested
=== RUN   TestBackend/in-operator
=== RUN   TestBackend/obligations-multi-stmt-with-oblig
=== RUN   TestBackend/blank-swagger
=== RUN   TestBackend/invalid-nonwildcarded-resource-property-in-context
=== RUN   TestBackend/grouping-with-not-and-parens
=== RUN   TestBackend/company.personnel
=== RUN   TestBackend/support-for-or-operator-context
=== RUN   TestBackend/statement-with-not
=== RUN   TestBackend/grouping-with-parens
=== RUN   TestBackend/obligations-simple
=== RUN   TestBackend/tags
=== RUN   TestBackend/matches
=== RUN   TestBackend/not-in-operator
--- PASS: TestBackend (0.06s)
    --- PASS: TestBackend/context-2 (0.01s)
    --- PASS: TestBackend/support-for-or-operator-simple (0.00s)
    --- PASS: TestBackend/statement-with-and (0.00s)
    --- PASS: TestBackend/multiple-statements (0.00s)
    --- PASS: TestBackend/no-swagger-actions (0.00s)
    --- PASS: TestBackend/missing-resource-errors (0.00s)
    --- PASS: TestBackend/invalid-resource-not-registered (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property-with-subject (0.00s)
    --- PASS: TestBackend/blank-subject (0.00s)
    --- PASS: TestBackend/context (0.00s)
    --- PASS: TestBackend/missing-to-errors (0.00s)
    --- PASS: TestBackend/invalid-resource-format-without-using-family.type-errors (0.00s)
    --- PASS: TestBackend/precedence-with-not (0.00s)
    --- PASS: TestBackend/obligations-wildcard (0.00s)
    --- PASS: TestBackend/obligations-multi-oblig-in-single-stmt (0.00s)
    --- PASS: TestBackend/simplest-statement-with-subject (0.00s)
    --- PASS: TestBackend/obligations-context (0.00s)
    --- PASS: TestBackend/missing-verb-errors (0.00s)
    --- PASS: TestBackend/context-nested (0.00s)
    --- PASS: TestBackend/in-operator (0.00s)
    --- PASS: TestBackend/obligations-multi-stmt-with-oblig (0.00s)
    --- PASS: TestBackend/blank-swagger (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property-in-context (0.00s)
    --- PASS: TestBackend/grouping-with-not-and-parens (0.00s)
    --- PASS: TestBackend/company.personnel (0.00s)
    --- PASS: TestBackend/support-for-or-operator-context (0.00s)
    --- PASS: TestBackend/statement-with-not (0.00s)
    --- PASS: TestBackend/grouping-with-parens (0.00s)
    --- PASS: TestBackend/obligations-simple (0.00s)
    --- PASS: TestBackend/tags (0.00s)
    --- PASS: TestBackend/matches (0.00s)
    --- PASS: TestBackend/not-in-operator (0.00s)
=== RUN   TestManySwaggers
=== RUN   TestManySwaggers/sw1
=== RUN   TestManySwaggers/sw2
=== RUN   TestManySwaggers/global
=== RUN   TestManySwaggers/empty
=== RUN   TestManySwaggers/global-sw1-sw2
=== RUN   TestManySwaggers/global-sw2-sw1
--- PASS: TestManySwaggers (0.01s)
    --- PASS: TestManySwaggers/sw1 (0.00s)
    --- PASS: TestManySwaggers/sw2 (0.00s)
    --- PASS: TestManySwaggers/global (0.00s)
    --- PASS: TestManySwaggers/empty (0.00s)
    --- PASS: TestManySwaggers/global-sw1-sw2 (0.00s)
    --- PASS: TestManySwaggers/global-sw2-sw1 (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/test  (cached)
=== RUN   TestNextToken
--- PASS: TestNextToken (0.00s)
=== RUN   TestContextToken
--- PASS: TestContextToken (0.00s)
=== RUN   TestNextTokenComment
--- PASS: TestNextTokenComment (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/lexer  (cached)
=== RUN   TestWhereClause
=== RUN   TestWhereClause/simple_user
=== RUN   TestWhereClause/simple_group
=== RUN   TestWhereClause/simple_where_clause_compare_equal
=== RUN   TestWhereClause/simple_where_clause_compare_not_equal
=== RUN   TestWhereClause/simple_where_clause_compare_int
=== RUN   TestWhereClause/simple_where_clause_compare_bool
=== RUN   TestWhereClause/single_where_clause_and
=== RUN   TestWhereClause/left_associative_where_clause_and
=== RUN   TestWhereClause/where_clause_grouped_conditions
=== RUN   TestWhereClause/where_clause_multiple_grouped_conditions
--- PASS: TestWhereClause (0.00s)
    --- PASS: TestWhereClause/simple_user (0.00s)
    --- PASS: TestWhereClause/simple_group (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_not_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_int (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_bool (0.00s)
    --- PASS: TestWhereClause/single_where_clause_and (0.00s)
    --- PASS: TestWhereClause/left_associative_where_clause_and (0.00s)
    --- PASS: TestWhereClause/where_clause_grouped_conditions (0.00s)
    --- PASS: TestWhereClause/where_clause_multiple_grouped_conditions (0.00s)
=== RUN   TestLetStatements
--- PASS: TestLetStatements (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/parser (cached)
=== RUN   TestLookupOperator
=== RUN   TestLookupOperator/invalid_empty
=== RUN   TestLookupOperator/equal_to
=== RUN   TestLookupOperator/not_equal
=== RUN   TestLookupOperator/less_than
=== RUN   TestLookupOperator/greater_than
=== RUN   TestLookupOperator/less_than_or_equal_to
=== RUN   TestLookupOperator/greater_than_or_equal_to
=== RUN   TestLookupOperator/not
=== RUN   TestLookupOperator/and
=== RUN   TestLookupOperator/or
=== RUN   TestLookupOperator/matches
--- PASS: TestLookupOperator (0.00s)
    --- PASS: TestLookupOperator/invalid_empty (0.00s)
    --- PASS: TestLookupOperator/equal_to (0.00s)
    --- PASS: TestLookupOperator/not_equal (0.00s)
    --- PASS: TestLookupOperator/less_than (0.00s)
    --- PASS: TestLookupOperator/greater_than (0.00s)
    --- PASS: TestLookupOperator/less_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/greater_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/not (0.00s)
    --- PASS: TestLookupOperator/and (0.00s)
    --- PASS: TestLookupOperator/or (0.00s)
    --- PASS: TestLookupOperator/matches (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/token  (cached)
=== RUN   TestIsNilInterface
--- PASS: TestIsNilInterface (0.00s)
=== RUN   TestNewTypeFromOpenAPIv3
    types_test.go:17: got type: petstore.pet
    types_test.go:19: got action: &types.swaggerAction{name:"allow", schema:(*openapi3.SchemaRef)(0xc0000b4f60)}
    types_test.go:23:     TODO: get type schema for action
    types_test.go:19: got action: &types.swaggerAction{name:"deny", schema:(*openapi3.SchemaRef)(nil)}
    types_test.go:23:     TODO: get type schema for action
--- PASS: TestNewTypeFromOpenAPIv3 (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/types  (cached)
```

```
$ make demo
./seal compile \
        -s docs/source/examples/petstore/petstore.jwt.swagger \
        -s docs/source/examples/petstore/petstore.tags.swagger \
        -s docs/source/examples/petstore/petstore.all.swagger \
        -f docs/source/examples/petstore/petstore.all.seal \
        > docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] logging level                                 logging.level=info
cat docs/source/examples/petstore/petstore.all.rego.compiled

package petstore.all

default allow = false
default deny = false

base_verbs := {
    "petstore.order": {
        "approve": [
            "approve",
        ],
        "deliver": [
            "deliver",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "ship": [
            "ship",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.pet": {
        "buy": [
            "buy",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "provision": [
            "provision",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sell": [
            "sell",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.user": {
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sign_in": [
            "sign_in",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_list_contains(seal_subject.groups, `boss`)
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["status"] == "delivered"
}

deny {
    seal_list_contains(seal_subject.groups, `regexp`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    re_match(`@petstore.swagger.io$`, seal_subject.jti)
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    seal_subject.iss != "petstore.swagger.io"
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["age"] <= 2
    input.ctx[i]["name"] == "specificPetName"
}

deny {
    seal_list_contains(seal_subject.groups, `banned`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

deny {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`sell`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] != "available"
}

deny {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line13_not1_cnd
    not line13_not2_cnd
}

allow {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line14_not1_cnd
}

allow {
    seal_list_contains(seal_subject.groups, `not_operator_precedence`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    not line15_not1_cnd
    input.ctx[i]["potty_trained"]
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["tags"]["endangered"] == "true"
}

allow {
    seal_list_contains(seal_subject.groups, `operators`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_subject.sub == `cto@petstore.swagger.io`
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`read`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "available"
}

allow {
    seal_list_contains(seal_subject.groups, `breeders_maltese`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "reserved"
    input.ctx[i]["breed"] == "maltese"
}

allow {
    seal_list_contains(seal_subject.groups, `employees`)
    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["status"] == "delivered"
}

allow {
    seal_list_contains(seal_subject.groups, `supervisors`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.user`, input.type)

    some i
    re_match(`.*@acme.com`, input.ctx[i]["email"])
}

line13_not1_cnd {
    some i
    input.ctx[i]["neutered"]
}

line13_not2_cnd {
    some i
    input.ctx[i]["potty_trained"]
}

line14_not1_cnd {
    some i
    input.ctx[i]["neutered"]
    input.ctx[i]["potty_trained"]
}

line15_not1_cnd {
    some i
    input.ctx[i]["neutered"]
}

obligations := {
    `stmt19`: [ `(ctx.marketplace != "amazon")` ],
    `stmt20`: [ `((ctx.occupation != "unemployed") and (ctx.salary > 200000))` ],
}

# rego functions defined by seal

# Helper to get the token payload.
seal_subject = payload {
    [header, payload, signature] := io.jwt.decode(input.jwt)
}

# seal_list_contains returns true if elem exists in list
seal_list_contains(list, elem) {
    list[_] = elem
}

cp docs/source/examples/petstore/petstore.all.rego.compiled docs/source/examples/petstore/petstore.all.rego
# beware that check-rego.sh reformats the compiled rego files...
./docs/source/examples/check-rego.sh docs/source/examples/petstore
+ IMAGE=openpolicyagent/opa:latest
+ [[ -z docs/source/examples/petstore ]]
+ [[ ! -d docs/source/examples/petstore ]]
++ cd docs/source/examples/petstore
++ /bin/pwd
+ TOP=/home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ cd /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ docker run -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest fmt -w .
+ case "$(basename $0)" in
++ basename ./docs/source/examples/check-rego.sh
+ docker run --rm -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest test -v petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego petstore.all.mock.json
data.petstore.all.test_in: PASS (40.009093ms)
data.petstore.all.test_in_negative: PASS (934.685µs)
data.petstore.all.test_not_operator_precedence_positive: PASS (40.456864ms)
data.petstore.all.test_not_operator_precedence_negative1: PASS (728.712µs)
data.petstore.all.test_not_operator_precedence_negative2: PASS (690.024µs)
data.petstore.all.test_not_operator_precedence_negative3: PASS (701.181µs)
data.petstore.all.test_regexp: PASS (2.320922ms)
data.petstore.all.test_regexp_negative: PASS (1.862146ms)
data.petstore.all.test_ctx_usage_multiply: PASS (1.82361ms)
data.petstore.all.test_ctx_usage_negative_multi_ctx: PASS (1.717527ms)
data.petstore.all.test_ctx_usage_negative: PASS (1.749503ms)
data.petstore.all.test_use_tags: PASS (1.823391ms)
data.petstore.all.test_use_tags_negative: PASS (1.801297ms)
data.petstore.all.test_use_tags_negative_missing_endangered_tag: PASS (1.637785ms)
data.petstore.all.test_use_petstore_jwt: PASS (1.779829ms)
data.petstore.all.test_use_petstore_jwt_negative: PASS (912.323µs)
data.petstore.all.test_banned_deny: PASS (920.747µs)
data.petstore.all.test_banned_deny_negative: PASS (779.053µs)
data.petstore.all.test_inspect: PASS (669.271µs)
data.petstore.all.test_inspect_negative: PASS (578.812µs)
data.petstore.all.test_read: PASS (798.354µs)
data.petstore.all.test_read_negative: PASS (2.139085ms)
data.petstore.all.test_manage_cto: PASS (1.279425ms)
data.petstore.all.test_blank_subject: PASS (1.52613ms)
data.petstore.all.test_bench_deny_in_map_species: PASS (244.505µs)
data.petstore.all.test_bench_deny_in_map_species_2nd: PASS (276.754µs)
data.petstore.all.test_bench_deny_in_map_species_negative: PASS (232.53µs)
data.petstore.all.test_bench_deny_in_map_species_negative_2nd: PASS (225.87µs)
--------------------------------------------------------------------------------
PASS: 28/28
+ git diff --exit-code petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests
```
