### PR TITLE
Fix generated obligations for multiple stmts inside context

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -307,8 +307,12 @@ line15_not1_cnd {
 }
 
 obligations := {
-    `stmt19`: [ `(ctx.marketplace != "amazon")` ],
-    `stmt20`: [ `((ctx.occupation != "unemployed") and (ctx.salary > 200000))` ],
+    `stmt19`: [
+        `(ctx.marketplace != "amazon")`,
+    ],
+    `stmt20`: [
+        `((ctx.occupation != "unemployed") and (ctx.salary > 200000))`,
+    ],
 }
 
 # rego functions defined by seal

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -131,20 +131,18 @@ type ContextCondition struct {
 
 func (a *ContextCondition) String() string {
 	var out bytes.Buffer
-	out.WriteString("{")
 	if !types.IsNilInterface(a.Subject) {
-		out.WriteString(fmt.Sprintf("Subject: %s, ", a.Subject.String()))
+		out.WriteString(a.Subject.String() + " ")
 	}
 	if !types.IsNilInterface(a.Where) {
-		out.WriteString(fmt.Sprintf("Where: %s, ", a.Where.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.Where.String()))
 	}
-	out.WriteString("}")
+	out.WriteString(";")
 	return out.String()
 }
 
 type ContextActionRule struct {
-	Context *ContextStatement
-
+	Context     *ContextStatement
 	Action      *Identifier
 	Subject     Subject
 	Verb        *Identifier
@@ -154,32 +152,35 @@ type ContextActionRule struct {
 
 func (a *ContextActionRule) String() string {
 	var out bytes.Buffer
-	out.WriteString("{")
 	if !types.IsNilInterface(a.Context) {
-		out.WriteString(fmt.Sprintf("Context: %s, ", a.Context.String()))
+		out.WriteString(fmt.Sprintf("%s { ", a.Context.String()))
 	}
 	if !types.IsNilInterface(a.Action) {
-		out.WriteString(fmt.Sprintf("Action: %s, ", a.Action.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.Action.String()))
 	}
 	if !types.IsNilInterface(a.Subject) {
-		out.WriteString(fmt.Sprintf("Subject: %s, ", a.Subject.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.Subject.String()))
 	}
 	if !types.IsNilInterface(a.Verb) {
-		out.WriteString(fmt.Sprintf("Verb: %s, ", a.Verb.String()))
+		out.WriteString(fmt.Sprintf("to %s ", a.Verb.String()))
 	}
 	if !types.IsNilInterface(a.TypePattern) {
-		out.WriteString(fmt.Sprintf("TypePattern: %s, ", a.TypePattern.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.TypePattern.String()))
 	}
 	if !types.IsNilInterface(a.Where) {
-		out.WriteString(fmt.Sprintf("Where: %s, ", a.Where.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.Where.String()))
 	}
-	out.WriteString("}")
+
+	if !types.IsNilInterface(a.Context) {
+		out.WriteString("}")
+	} else {
+		out.WriteString(";")
+	}
 	return out.String()
 }
 
 type ContextStatement struct {
-	Token token.Token
-
+	Token       token.Token
 	Conditions  []*ContextCondition
 	Verb        *Identifier
 	TypePattern *Identifier
@@ -190,24 +191,21 @@ func (a *ContextStatement) statementNode()       {}
 func (a *ContextStatement) TokenLiteral() string { return a.Token.Literal }
 func (a *ContextStatement) String() string {
 	var out bytes.Buffer
-	out.WriteString("{")
-	out.WriteString(fmt.Sprintf("Token: %s %s", string(a.Token.Type), a.Token.Literal))
-	out.WriteString(fmt.Sprintf(", Conditions: len=%d [", len(a.Conditions)))
+	out.WriteString(fmt.Sprintf("%s { ", a.TokenLiteral()))
 	for _, cnd := range a.Conditions {
-		out.WriteString(fmt.Sprintf(" %s,", cnd.String()))
+		out.WriteString(fmt.Sprintf("%s ", cnd.String()))
 	}
-	out.WriteString("]")
+	out.WriteString("} ")
 	if !types.IsNilInterface(a.Verb) {
-		out.WriteString(fmt.Sprintf(", Verb: %s", a.Verb.String()))
+		out.WriteString(fmt.Sprintf("to %s ", a.Verb.String()))
 	}
 	if !types.IsNilInterface(a.TypePattern) {
-		out.WriteString(fmt.Sprintf(", TypePattern: %s", a.TypePattern.String()))
+		out.WriteString(fmt.Sprintf("%s ", a.TypePattern.String()))
 	}
-	out.WriteString(fmt.Sprintf(", ActionRules: len=%d [", len(a.ActionRules)))
+	out.WriteString("{ ")
 	for _, act := range a.ActionRules {
-		out.WriteString(fmt.Sprintf(" %s,", act.String()))
+		out.WriteString(fmt.Sprintf("%s ", act.String()))
 	}
-	out.WriteString("]")
 	out.WriteString("}")
 	return out.String()
 }

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -111,8 +111,12 @@ func (a *ActionStatement) String() string {
 	if !types.IsNilInterface(a.Subject) {
 		out.WriteString(a.Subject.String() + " ")
 	}
-	out.WriteString("to " + a.Verb.TokenLiteral() + " ")
-	out.WriteString(a.TypePattern.TokenLiteral())
+	if !types.IsNilInterface(a.Verb) {
+		out.WriteString("to " + a.Verb.TokenLiteral() + " ")
+	}
+	if !types.IsNilInterface(a.TypePattern) {
+		out.WriteString(a.TypePattern.TokenLiteral())
+	}
 	if !types.IsNilInterface(a.WhereClause) {
 		out.WriteString(" " + a.WhereClause.String())
 	}
@@ -124,6 +128,20 @@ type ContextCondition struct {
 	Subject Subject
 	Where   *WhereClause
 }
+
+func (a *ContextCondition) String() string {
+	var out bytes.Buffer
+	out.WriteString("{")
+	if !types.IsNilInterface(a.Subject) {
+		out.WriteString(fmt.Sprintf("Subject: %s, ", a.Subject.String()))
+	}
+	if !types.IsNilInterface(a.Where) {
+		out.WriteString(fmt.Sprintf("Where: %s, ", a.Where.String()))
+	}
+	out.WriteString("}")
+	return out.String()
+}
+
 type ContextActionRule struct {
 	Context *ContextStatement
 
@@ -133,6 +151,32 @@ type ContextActionRule struct {
 	TypePattern *Identifier
 	Where       *WhereClause
 }
+
+func (a *ContextActionRule) String() string {
+	var out bytes.Buffer
+	out.WriteString("{")
+	if !types.IsNilInterface(a.Context) {
+		out.WriteString(fmt.Sprintf("Context: %s, ", a.Context.String()))
+	}
+	if !types.IsNilInterface(a.Action) {
+		out.WriteString(fmt.Sprintf("Action: %s, ", a.Action.String()))
+	}
+	if !types.IsNilInterface(a.Subject) {
+		out.WriteString(fmt.Sprintf("Subject: %s, ", a.Subject.String()))
+	}
+	if !types.IsNilInterface(a.Verb) {
+		out.WriteString(fmt.Sprintf("Verb: %s, ", a.Verb.String()))
+	}
+	if !types.IsNilInterface(a.TypePattern) {
+		out.WriteString(fmt.Sprintf("TypePattern: %s, ", a.TypePattern.String()))
+	}
+	if !types.IsNilInterface(a.Where) {
+		out.WriteString(fmt.Sprintf("Where: %s, ", a.Where.String()))
+	}
+	out.WriteString("}")
+	return out.String()
+}
+
 type ContextStatement struct {
 	Token token.Token
 
@@ -145,7 +189,27 @@ type ContextStatement struct {
 func (a *ContextStatement) statementNode()       {}
 func (a *ContextStatement) TokenLiteral() string { return a.Token.Literal }
 func (a *ContextStatement) String() string {
-	return "context TODO"
+	var out bytes.Buffer
+	out.WriteString("{")
+	out.WriteString(fmt.Sprintf("Token: %s %s", string(a.Token.Type), a.Token.Literal))
+	out.WriteString(fmt.Sprintf(", Conditions: len=%d [", len(a.Conditions)))
+	for _, cnd := range a.Conditions {
+		out.WriteString(fmt.Sprintf(" %s,", cnd.String()))
+	}
+	out.WriteString("]")
+	if !types.IsNilInterface(a.Verb) {
+		out.WriteString(fmt.Sprintf(", Verb: %s", a.Verb.String()))
+	}
+	if !types.IsNilInterface(a.TypePattern) {
+		out.WriteString(fmt.Sprintf(", TypePattern: %s", a.TypePattern.String()))
+	}
+	out.WriteString(fmt.Sprintf(", ActionRules: len=%d [", len(a.ActionRules)))
+	for _, act := range a.ActionRules {
+		out.WriteString(fmt.Sprintf(" %s,", act.String()))
+	}
+	out.WriteString("]")
+	out.WriteString("}")
+	return out.String()
 }
 
 type SubjectGroup struct {

--- a/pkg/compiler/test/policy_compiler_test.go
+++ b/pkg/compiler/test/policy_compiler_test.go
@@ -95,7 +95,7 @@ expected next token to be to, got ; instead`),
 			packageName:    "products.errors",
 			swaggerContent: []string{"company"},
 			policyString:   `context { where ctx.id == "guid"; } { allow subject group everyone to inspect products.inventory where ctx.ame == "foo"; }`,
-			compilerError:  errors.New(`could not compile package products.errors: compiler_rego: at #0 {Token: context context, Conditions: len=1 [ {Where: where (ctx.id == "guid"), },], ActionRules: len=1 [ {Action: allow, Subject: subject group everyone, Verb: inspect, TypePattern: products.inventory, Where: where (ctx.ame == "foo"), },]} due to error: Unknown property 'ame' of type 'products.inventory'`),
+			compilerError:  errors.New(`could not compile package products.errors: compiler_rego: at #0 context { where (ctx.id == "guid") ; } { allow subject group everyone to inspect products.inventory where (ctx.ame == "foo") ; } due to error: Unknown property 'ame' of type 'products.inventory'`),
 			// TODO: why is this error not caught in front-end parser,
 			//       but only caught in back-end compiler?
 			//       Compare to two previous test cases.

--- a/pkg/parser/condition.go
+++ b/pkg/parser/condition.go
@@ -134,7 +134,7 @@ func (p *Parser) parseInfixCondition(left ast.Condition) ast.Condition {
 	precedence := p.curPrecedence()
 	p.nextToken()
 	condition.Right = p.parseCondition(precedence)
-	logger.WithField("condition", fmt.Sprintf("%#v", condition)).Debug("infix-condition")
+	logger.WithField("condition", fmt.Sprintf("%#v", condition)).Trace("infix-condition")
 
 	// TODO GH-42
 	if condition.Token.Type == token.OR {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -34,23 +34,23 @@ func New(l *lexer.Lexer, domainTypes []types.Type) *Parser {
 	for i, t := range domainTypes {
 		s := fmt.Sprintf("%s.%s", t.GetGroup(), t.GetName())
 		ilogger := logger.WithField("i", i).WithField("domain_type", s)
-		ilogger.WithField("verbs", domainTypes[i].GetVerbs()).Debug("verbs")
-		ilogger.WithField("defaultaction", domainTypes[i].DefaultAction()).Debug("defaultaction")
-		ilogger.WithField("actions", domainTypes[i].GetActions()).Debug("actions")
-		ilogger.WithField("properties", domainTypes[i].GetProperties()).Debug("properties")
+		ilogger.WithField("verbs", domainTypes[i].GetVerbs()).Trace("verbs")
+		ilogger.WithField("defaultaction", domainTypes[i].DefaultAction()).Trace("defaultaction")
+		ilogger.WithField("actions", domainTypes[i].GetActions()).Trace("actions")
+		ilogger.WithField("properties", domainTypes[i].GetProperties()).Trace("properties")
 		for pname, pprop := range domainTypes[i].GetProperties() {
 			plogger := ilogger.WithField("property_name", pname)
 			x_seal_type, ok, err := pprop.GetExtensionProp("x-seal-type")
 			if err != nil {
 				p.errors = append(p.errors, err.Error())
 			} else if ok {
-				plogger.WithField("x_seal_type", x_seal_type).Debug("x_seal_type")
+				plogger.WithField("x_seal_type", x_seal_type).Trace("x_seal_type")
 			}
 			x_seal_obligation, ok, err := pprop.GetExtensionProp("x-seal-obligation")
 			if err != nil {
 				p.errors = append(p.errors, err.Error())
 			} else if ok {
-				plogger.WithField("x_seal_obligation", x_seal_obligation).Debug("x_seal_obligation")
+				plogger.WithField("x_seal_obligation", x_seal_obligation).Trace("x_seal_obligation")
 			}
 		}
 		p.domainTypes[s] = domainTypes[i]
@@ -172,7 +172,7 @@ func (p *Parser) validateActionStatement(stmt *ast.ActionStatement) error {
 
 		if !types.IsNilInterface(stmt.WhereClause) {
 			typs := stmt.WhereClause.GetTypes()
-			logrus.WithField("types", typs).Debug("where clause types")
+			logrus.WithField("types", typs).Trace("where clause types")
 			for _, l := range typs {
 				v := !types.IsValidProperty(t, l.Value)                // v == true for invalid property
 				v = v && !types.IsValidSubject(p.domainTypes, l.Value) // v == true for invalid subject too (mean jwt)
@@ -244,7 +244,7 @@ func (p *Parser) validateContextStatement(stmt *ast.ContextStatement) error {
 
 				if !types.IsNilInterface(cond.Where) {
 					typs := cond.Where.GetTypes()
-					logrus.WithField("types", typs).Debug("where clause types")
+					logrus.WithField("types", typs).Trace("where clause types")
 
 					for _, l := range typs {
 						v := !types.IsValidProperty(t, l.Value)                // v == true for invalid property
@@ -267,6 +267,7 @@ func (p *Parser) validateContextStatement(stmt *ast.ContextStatement) error {
 }
 
 func (p *Parser) parseContextStatement() (stmt *ast.ContextStatement) {
+	logger := logrus.WithField("method", "parseContextStatement")
 	stmt = &ast.ContextStatement{
 		Conditions:  []*ast.ContextCondition{},
 		Token:       p.curToken,
@@ -405,6 +406,7 @@ func (p *Parser) parseContextStatement() (stmt *ast.ContextStatement) {
 		return nil
 	}
 
+	logger.WithField("stmt", stmt.String()).Trace("parsed_context_stmt")
 	return stmt
 }
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -73,7 +73,7 @@ func LookupIdent(ident string) TokenType {
 }
 
 func LookupOperatorComparison(op string) TokenType {
-	logrus.WithField("op", op).Debug("LookupOperatorComparison")
+	logrus.WithField("op", op).Trace("LookupOperatorComparison")
 	switch op {
 	default:
 		return ILLEGAL
@@ -92,7 +92,7 @@ func LookupOperatorComparison(op string) TokenType {
 }
 
 func LookupOperatorLogical(op string) TokenType {
-	logrus.WithField("op", op).Debug("LookupOperatorLogical")
+	logrus.WithField("op", op).Trace("LookupOperatorLogical")
 	switch op {
 	default:
 		return ILLEGAL
@@ -106,7 +106,7 @@ func LookupOperatorLogical(op string) TokenType {
 }
 
 func LookupOperator(op string) TokenType {
-	logrus.WithField("op", op).Debug("LookupOperator")
+	logrus.WithField("op", op).Trace("LookupOperator")
 	type funcLookupOperator func(string) TokenType
 
 	for _, f := range []funcLookupOperator{

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,7 +42,7 @@ func NewTypeFromOpenAPIv3(spec []byte) ([]Type, error) {
 		slogger.WithFields(logrus.Fields{
 			"schema":    fmt.Sprintf("%+v", *v.Value),
 			"extension": fmt.Sprintf("%+v", extension),
-		}).Debug("schema")
+		}).Trace("schema")
 		if err != nil {
 			return nil, fmt.Errorf("swagger model %s has errors: %s", k, err)
 		}
@@ -54,7 +54,7 @@ func NewTypeFromOpenAPIv3(spec []byte) ([]Type, error) {
 		case TYPE_NONE:
 			break
 		default:
-			slogger.WithField("extension_type", extension.Type).Debug("ignoring_extension_type")
+			slogger.WithField("extension_type", extension.Type).Trace("ignoring_extension_type")
 			continue
 		}
 


### PR DESCRIPTION
Also changed all debug-level logging to trace-level so calling application can enable debug-level without fear of enabling the voluminous/verbose trace-level logging of the seal parser/compiler

```
$ make test
?       github.com/infobloxopen/seal    [no test files]
?       github.com/infobloxopen/seal/cmd        [no test files]
?       github.com/infobloxopen/seal/pkg/ast    [no test files]
?       github.com/infobloxopen/seal/pkg/compiler       [no test files]
?       github.com/infobloxopen/seal/pkg/compiler/error [no test files]
=== RUN   TestCompile
    rego_test.go:180: validate policy: allow subject group foo to manage petstore.pet;
    rego_test.go:181: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_list_contains(seal_subject.groups, `foo`)
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        obligations := {
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
    rego_test.go:180: validate policy: allow subject user foo to manage petstore.pet;
    rego_test.go:181: rego language output generated:
        
        package foo
        
        default allow = false
        default deny = false
        
        base_verbs := {
        }
        
        allow {
            seal_subject.sub == `foo`
            seal_list_contains(base_verbs[input.type][`manage`], input.verb)
            re_match(`petstore.pet`, input.type)
        }
        
        obligations := {
        }
        
        # rego functions defined by seal
        
        # Helper to get the token payload.
        seal_subject = payload {
            [header, payload, signature] := io.jwt.decode(input.jwt)
        }
        
        # seal_list_contains returns true if elem exists in list
        seal_list_contains(list, elem) {
            list[_] = elem
        }
--- PASS: TestCompile (0.00s)
=== RUN   TestCleanupSomeI
--- PASS: TestCleanupSomeI (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/rego  (cached)
=== RUN   TestCompiler
--- PASS: TestCompiler (0.00s)
=== RUN   TestLanguages
    compiler_test.go:86: validate list of languages - supported languages: []string{"rego"}
--- PASS: TestLanguages (0.00s)
=== RUN   TestBackend
=== RUN   TestBackend/grouping-with-parens
=== RUN   TestBackend/obligations-context
=== RUN   TestBackend/missing-verb-errors
=== RUN   TestBackend/statement-with-not
=== RUN   TestBackend/tags
=== RUN   TestBackend/no-swagger-actions
=== RUN   TestBackend/support-for-or-operator-simple
=== RUN   TestBackend/company.personnel
=== RUN   TestBackend/blank-subject
=== RUN   TestBackend/context
=== RUN   TestBackend/obligations-simple
=== RUN   TestBackend/invalid-resource-format-without-using-family.type-errors
=== RUN   TestBackend/invalid-nonwildcarded-resource-property-in-context
=== RUN   TestBackend/in-operator
=== RUN   TestBackend/invalid-nonwildcarded-resource-property
=== RUN   TestBackend/missing-resource-errors
=== RUN   TestBackend/precedence-with-not
=== RUN   TestBackend/context-2
=== RUN   TestBackend/context-nested
=== RUN   TestBackend/obligations-wildcard
=== RUN   TestBackend/missing-to-errors
=== RUN   TestBackend/invalid-resource-not-registered
=== RUN   TestBackend/invalid-nonwildcarded-resource-property-with-subject
=== RUN   TestBackend/simplest-statement-with-subject
=== RUN   TestBackend/grouping-with-not-and-parens
=== RUN   TestBackend/blank-swagger
=== RUN   TestBackend/not-in-operator
=== RUN   TestBackend/obligations-multi-oblig-in-single-stmt
=== RUN   TestBackend/obligations-multi-stmt-with-oblig
=== RUN   TestBackend/support-for-or-operator-context
=== RUN   TestBackend/multiple-statements
=== RUN   TestBackend/matches
=== RUN   TestBackend/statement-with-and
--- PASS: TestBackend (0.06s)
    --- PASS: TestBackend/grouping-with-parens (0.00s)
    --- PASS: TestBackend/obligations-context (0.00s)
    --- PASS: TestBackend/missing-verb-errors (0.00s)
    --- PASS: TestBackend/statement-with-not (0.00s)
    --- PASS: TestBackend/tags (0.00s)
    --- PASS: TestBackend/no-swagger-actions (0.00s)
    --- PASS: TestBackend/support-for-or-operator-simple (0.00s)
    --- PASS: TestBackend/company.personnel (0.00s)
    --- PASS: TestBackend/blank-subject (0.00s)
    --- PASS: TestBackend/context (0.00s)
    --- PASS: TestBackend/obligations-simple (0.00s)
    --- PASS: TestBackend/invalid-resource-format-without-using-family.type-errors (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property-in-context (0.00s)
    --- PASS: TestBackend/in-operator (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property (0.00s)
    --- PASS: TestBackend/missing-resource-errors (0.00s)
    --- PASS: TestBackend/precedence-with-not (0.00s)
    --- PASS: TestBackend/context-2 (0.00s)
    --- PASS: TestBackend/context-nested (0.00s)
    --- PASS: TestBackend/obligations-wildcard (0.00s)
    --- PASS: TestBackend/missing-to-errors (0.00s)
    --- PASS: TestBackend/invalid-resource-not-registered (0.00s)
    --- PASS: TestBackend/invalid-nonwildcarded-resource-property-with-subject (0.00s)
    --- PASS: TestBackend/simplest-statement-with-subject (0.00s)
    --- PASS: TestBackend/grouping-with-not-and-parens (0.00s)
    --- PASS: TestBackend/blank-swagger (0.00s)
    --- PASS: TestBackend/not-in-operator (0.00s)
    --- PASS: TestBackend/obligations-multi-oblig-in-single-stmt (0.00s)
    --- PASS: TestBackend/obligations-multi-stmt-with-oblig (0.00s)
    --- PASS: TestBackend/support-for-or-operator-context (0.00s)
    --- PASS: TestBackend/multiple-statements (0.00s)
    --- PASS: TestBackend/matches (0.00s)
    --- PASS: TestBackend/statement-with-and (0.00s)
=== RUN   TestManySwaggers
=== RUN   TestManySwaggers/global-sw2-sw1
=== RUN   TestManySwaggers/sw1
=== RUN   TestManySwaggers/sw2
=== RUN   TestManySwaggers/global
=== RUN   TestManySwaggers/empty
=== RUN   TestManySwaggers/global-sw1-sw2
--- PASS: TestManySwaggers (0.01s)
    --- PASS: TestManySwaggers/global-sw2-sw1 (0.00s)
    --- PASS: TestManySwaggers/sw1 (0.00s)
    --- PASS: TestManySwaggers/sw2 (0.00s)
    --- PASS: TestManySwaggers/global (0.00s)
    --- PASS: TestManySwaggers/empty (0.00s)
    --- PASS: TestManySwaggers/global-sw1-sw2 (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/test  (cached)
=== RUN   TestNextToken
--- PASS: TestNextToken (0.00s)
=== RUN   TestContextToken
--- PASS: TestContextToken (0.00s)
=== RUN   TestNextTokenComment
--- PASS: TestNextTokenComment (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/lexer  (cached)
=== RUN   TestWhereClause
=== RUN   TestWhereClause/simple_user
=== RUN   TestWhereClause/simple_group
=== RUN   TestWhereClause/simple_where_clause_compare_equal
=== RUN   TestWhereClause/simple_where_clause_compare_not_equal
=== RUN   TestWhereClause/simple_where_clause_compare_int
=== RUN   TestWhereClause/simple_where_clause_compare_bool
=== RUN   TestWhereClause/single_where_clause_and
=== RUN   TestWhereClause/left_associative_where_clause_and
=== RUN   TestWhereClause/where_clause_grouped_conditions
=== RUN   TestWhereClause/where_clause_multiple_grouped_conditions
--- PASS: TestWhereClause (0.00s)
    --- PASS: TestWhereClause/simple_user (0.00s)
    --- PASS: TestWhereClause/simple_group (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_not_equal (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_int (0.00s)
    --- PASS: TestWhereClause/simple_where_clause_compare_bool (0.00s)
    --- PASS: TestWhereClause/single_where_clause_and (0.00s)
    --- PASS: TestWhereClause/left_associative_where_clause_and (0.00s)
    --- PASS: TestWhereClause/where_clause_grouped_conditions (0.00s)
    --- PASS: TestWhereClause/where_clause_multiple_grouped_conditions (0.00s)
=== RUN   TestLetStatements
--- PASS: TestLetStatements (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/parser (cached)
=== RUN   TestLookupOperator
=== RUN   TestLookupOperator/invalid_empty
=== RUN   TestLookupOperator/equal_to
=== RUN   TestLookupOperator/not_equal
=== RUN   TestLookupOperator/less_than
=== RUN   TestLookupOperator/greater_than
=== RUN   TestLookupOperator/less_than_or_equal_to
=== RUN   TestLookupOperator/greater_than_or_equal_to
=== RUN   TestLookupOperator/not
=== RUN   TestLookupOperator/and
=== RUN   TestLookupOperator/or
=== RUN   TestLookupOperator/matches
--- PASS: TestLookupOperator (0.00s)
    --- PASS: TestLookupOperator/invalid_empty (0.00s)
    --- PASS: TestLookupOperator/equal_to (0.00s)
    --- PASS: TestLookupOperator/not_equal (0.00s)
    --- PASS: TestLookupOperator/less_than (0.00s)
    --- PASS: TestLookupOperator/greater_than (0.00s)
    --- PASS: TestLookupOperator/less_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/greater_than_or_equal_to (0.00s)
    --- PASS: TestLookupOperator/not (0.00s)
    --- PASS: TestLookupOperator/and (0.00s)
    --- PASS: TestLookupOperator/or (0.00s)
    --- PASS: TestLookupOperator/matches (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/token  (cached)
=== RUN   TestIsNilInterface
--- PASS: TestIsNilInterface (0.00s)
=== RUN   TestNewTypeFromOpenAPIv3
    types_test.go:17: got type: petstore.pet
    types_test.go:19: got action: &types.swaggerAction{name:"deny", schema:(*openapi3.SchemaRef)(nil)}
    types_test.go:23:     TODO: get type schema for action
    types_test.go:19: got action: &types.swaggerAction{name:"allow", schema:(*openapi3.SchemaRef)(0xc00000efa0)}
    types_test.go:23:     TODO: get type schema for action
--- PASS: TestNewTypeFromOpenAPIv3 (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/types  (cached)
```

```
$ make demo
./seal compile \
        -s docs/source/examples/petstore/petstore.jwt.swagger \
        -s docs/source/examples/petstore/petstore.tags.swagger \
        -s docs/source/examples/petstore/petstore.all.swagger \
        -f docs/source/examples/petstore/petstore.all.seal \
        > docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] set logging format                            logging.format=text
INFO[0000] logging level                                 logging.level=info
cat docs/source/examples/petstore/petstore.all.rego.compiled

package petstore.all

default allow = false
default deny = false

base_verbs := {
    "petstore.order": {
        "approve": [
            "approve",
        ],
        "deliver": [
            "deliver",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "ship": [
            "ship",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.pet": {
        "buy": [
            "buy",
        ],
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "provision": [
            "provision",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sell": [
            "sell",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
    "petstore.user": {
        "inspect": [
            "list",
            "watch",
        ],
        "manage": [
            "create",
            "delete",
            "update",
            "get",
            "list",
            "watch",
        ],
        "read": [
            "get",
            "list",
            "watch",
        ],
        "sign_in": [
            "sign_in",
        ],
        "use": [
            "update",
            "get",
            "list",
            "watch",
        ],
    },
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_list_contains(seal_subject.groups, `boss`)
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)

    some i
    input.ctx[i]["id"] == "-1"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.order`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.user`, input.type)
    seal_subject.iss != "context.petstore.swagger.io"
}

deny {
    seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["status"] == "delivered"
}

deny {
    seal_list_contains(seal_subject.groups, `regexp`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    re_match(`@petstore.swagger.io$`, seal_subject.jti)
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
    seal_subject.iss != "petstore.swagger.io"
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["age"] <= 2
    input.ctx[i]["name"] == "specificPetName"
}

deny {
    seal_list_contains(seal_subject.groups, `banned`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

deny {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`sell`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] != "available"
}

deny {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line13_not1_cnd
    not line13_not2_cnd
}

allow {
    seal_list_contains(seal_subject.groups, `fussy`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)
    not line14_not1_cnd
}

allow {
    seal_list_contains(seal_subject.groups, `not_operator_precedence`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    not line15_not1_cnd
    input.ctx[i]["potty_trained"]
}

deny {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["tags"]["endangered"] == "true"
}

allow {
    seal_list_contains(seal_subject.groups, `operators`)
    seal_list_contains(base_verbs[input.type][`use`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `managers`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_subject.sub == `cto@petstore.swagger.io`
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.*`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `everyone`)
    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`read`], input.verb)
    re_match(`petstore.pet`, input.type)
}

allow {
    seal_list_contains(seal_subject.groups, `customers`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "available"
}

allow {
    seal_list_contains(seal_subject.groups, `breeders_maltese`)
    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
    re_match(`petstore.pet`, input.type)

    some i
    input.ctx[i]["status"] == "reserved"
    input.ctx[i]["breed"] == "maltese"
}

allow {
    seal_list_contains(seal_subject.groups, `employees`)
    seal_list_contains(base_verbs[input.type][`inspect`], input.verb)
    re_match(`petstore.order`, input.type)

    some i
    input.ctx[i]["status"] == "delivered"
}

allow {
    seal_list_contains(seal_subject.groups, `supervisors`)
    seal_list_contains(base_verbs[input.type][`manage`], input.verb)
    re_match(`petstore.user`, input.type)

    some i
    re_match(`.*@acme.com`, input.ctx[i]["email"])
}

line13_not1_cnd {
    some i
    input.ctx[i]["neutered"]
}

line13_not2_cnd {
    some i
    input.ctx[i]["potty_trained"]
}

line14_not1_cnd {
    some i
    input.ctx[i]["neutered"]
    input.ctx[i]["potty_trained"]
}

line15_not1_cnd {
    some i
    input.ctx[i]["neutered"]
}

obligations := {
    `stmt19`: [
        `(ctx.marketplace != "amazon")`,
    ],
    `stmt20`: [
        `((ctx.occupation != "unemployed") and (ctx.salary > 200000))`,
    ],
}

# rego functions defined by seal

# Helper to get the token payload.
seal_subject = payload {
    [header, payload, signature] := io.jwt.decode(input.jwt)
}

# seal_list_contains returns true if elem exists in list
seal_list_contains(list, elem) {
    list[_] = elem
}

cp docs/source/examples/petstore/petstore.all.rego.compiled docs/source/examples/petstore/petstore.all.rego
# beware that check-rego.sh reformats the compiled rego files...
./docs/source/examples/check-rego.sh docs/source/examples/petstore
+ IMAGE=openpolicyagent/opa:latest
+ [[ -z docs/source/examples/petstore ]]
+ [[ ! -d docs/source/examples/petstore ]]
++ cd docs/source/examples/petstore
++ /bin/pwd
+ TOP=/home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ cd /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore
+ docker run -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest fmt -w .
+ case "$(basename $0)" in
++ basename ./docs/source/examples/check-rego.sh
+ docker run --rm -v /home/riccho/go/src/github.com/infobloxopen/seal/docs/source/examples/petstore:/data -w /data openpolicyagent/opa:latest test -v petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego petstore.all.mock.json
data.petstore.all.test_in: PASS (2.240061ms)
data.petstore.all.test_in_negative: PASS (1.570174ms)
data.petstore.all.test_not_operator_precedence_positive: PASS (1.265319ms)
data.petstore.all.test_not_operator_precedence_negative1: PASS (1.224039ms)
data.petstore.all.test_not_operator_precedence_negative2: PASS (1.028918ms)
data.petstore.all.test_not_operator_precedence_negative3: PASS (1.050024ms)
data.petstore.all.test_regexp: PASS (1.628961ms)
data.petstore.all.test_regexp_negative: PASS (2.057085ms)
data.petstore.all.test_ctx_usage_multiply: PASS (1.230118ms)
data.petstore.all.test_ctx_usage_negative_multi_ctx: PASS (1.203425ms)
data.petstore.all.test_ctx_usage_negative: PASS (1.425766ms)
data.petstore.all.test_use_tags: PASS (1.387103ms)
data.petstore.all.test_use_tags_negative: PASS (1.480513ms)
data.petstore.all.test_use_tags_negative_missing_endangered_tag: PASS (1.541309ms)
data.petstore.all.test_use_petstore_jwt: PASS (2.701714ms)
data.petstore.all.test_use_petstore_jwt_negative: PASS (1.690335ms)
data.petstore.all.test_banned_deny: PASS (1.605848ms)
data.petstore.all.test_banned_deny_negative: PASS (1.24342ms)
data.petstore.all.test_inspect: PASS (1.215324ms)
data.petstore.all.test_inspect_negative: PASS (1.045806ms)
data.petstore.all.test_read: PASS (2.01031ms)
data.petstore.all.test_read_negative: PASS (2.080385ms)
data.petstore.all.test_manage_cto: PASS (1.87025ms)
data.petstore.all.test_blank_subject: PASS (1.523673ms)
data.petstore.all.test_bench_deny_in_map_species: PASS (297.766µs)
data.petstore.all.test_bench_deny_in_map_species_2nd: PASS (232.57µs)
data.petstore.all.test_bench_deny_in_map_species_negative: PASS (230.929µs)
data.petstore.all.test_bench_deny_in_map_species_negative_2nd: PASS (215.824µs)
--------------------------------------------------------------------------------
PASS: 28/28
+ git diff --exit-code petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests
```