### PR TITLE
Add exported sqlcompiler.CompileCondition() fn

### DIFF
--- a/pkg/compiler/sql/sql_condition.go
+++ b/pkg/compiler/sql/sql_condition.go
@@ -1,0 +1,139 @@
+package sqlcompiler
+
+// https://www.postgresql.org/docs/9.3/functions-matching.html
+// https://dba.stackexchange.com/questions/10694/pattern-matching-with-like-similar-to-or-regular-expressions-in-postgresql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/infobloxopen/seal/pkg/ast"
+	"github.com/infobloxopen/seal/pkg/parser"
+	"github.com/infobloxopen/seal/pkg/token"
+	"github.com/infobloxopen/seal/pkg/types"
+)
+
+// SQL dialects
+const (
+	_ int = iota
+	DialectUnknown
+	DialectPostgres
+)
+
+// CompileCondition compiles the given input condition string into an SQL condition string.
+// Optional colNameReplacer can be specified to adjust the column names in the SQL condition.
+func CompileCondition(dialect int, singleCondition string, colNameReplacer *strings.Replacer) (string, error) {
+	logger := logrus.WithField("method", "CompileCondition")
+	ast, err := parser.ParseCondition(singleCondition)
+	if err != nil {
+		return "", err
+	} else if ast == nil {
+		return "", fmt.Errorf("Unknown error parsing condition: %s", singleCondition)
+	}
+
+	singleWhere, err := astConditionToSQL(dialect, ast, colNameReplacer, 0)
+	if err != nil {
+		return "", err
+	}
+	logger.WithField("where", singleWhere).Trace("single_where_clause")
+
+	return singleWhere, nil
+}
+
+func astConditionToSQL(dialect int, o ast.Condition, colNameReplacer *strings.Replacer, lvl int) (string, error) {
+	logger := logrus.WithField("method", "astConditionToSQL").WithField("lvl", lvl).WithField("condition", o.String())
+	if types.IsNilInterface(o) {
+		return "", nil
+	}
+
+	logger.WithField("type", fmt.Sprintf("%#v", o)).Trace("astConditionToSQL")
+
+	sqlReplacer := strings.NewReplacer(
+		`'`, `''`,
+	)
+
+	switch s := o.(type) {
+	case *ast.Identifier:
+		switch s.Token.Type {
+		case token.LITERAL:
+			result := s.String()
+
+			// If double-quoted string literal:
+			//   Escape any single-quotes
+			//   Replace begin/end double-quotes with single-quotes
+			if strings.HasPrefix(result, `"`) && strings.HasSuffix(result, `"`) {
+				result = sqlReplacer.Replace(result)
+				result = `'` + result[1:len(result)-1] + `'`
+			}
+
+			logger.WithField("result", result).Trace("s.Token.Type==token.LITERAL")
+			return result, nil
+		}
+
+		id := s.Token.Literal
+		if strings.ContainsAny(id, `["']`) {
+			return "", fmt.Errorf("map/array indexing not supported yet: %s", id)
+		}
+
+		if colNameReplacer != nil {
+			id = colNameReplacer.Replace(id)
+		}
+
+		logger.WithField("id", id).Trace("s.Token.Type!=token.LITERAL")
+		return id, nil
+
+	case *ast.IntegerLiteral:
+		id := s.Token.Literal
+		return id, nil
+
+	case *ast.PrefixCondition:
+		rhs, err := astConditionToSQL(dialect, s.Right, colNameReplacer, lvl+1)
+		if err != nil {
+			return "", err
+		}
+
+		switch s.Token.Type {
+		case token.NOT:
+			return fmt.Sprintf("(NOT %s)", rhs), nil
+		}
+
+		logger.WithField("token_type", s.Token.Type).Warn("unknown_prefix_condition")
+		return fmt.Sprintf("(%s %s)", s.Token.Literal, rhs), nil
+
+	case *ast.InfixCondition:
+		lhs, err := astConditionToSQL(dialect, s.Left, colNameReplacer, lvl+1)
+		if err != nil {
+			return "", err
+		}
+
+		rhs, err := astConditionToSQL(dialect, s.Right, colNameReplacer, lvl+1)
+		if err != nil {
+			return "", err
+		}
+
+		result := ""
+		switch s.Token.Type {
+		case token.AND:
+			result = fmt.Sprintf("(%s AND %s)", lhs, rhs)
+		case token.OR:
+			result = fmt.Sprintf("(%s OR %s)", lhs, rhs)
+		case token.OP_EQUAL_TO:
+			result = fmt.Sprintf("(%s = %s)", lhs, rhs)
+		case token.OP_MATCH:
+			result = fmt.Sprintf("(%s ~ %s)", lhs, rhs)
+		case token.OP_IN:
+			//TODO: select * from permissions where id in ('tag-manage', 'tag-view');
+			return "", fmt.Errorf("IN operator not supported yet: %s", o)
+		default:
+			result = fmt.Sprintf("%s %s %s", lhs, s.Token.Literal, rhs)
+		}
+
+		return result, nil
+
+	default:
+		logger.WithField("type", fmt.Sprintf("%#v", o)).Warn("unknown_condition")
+		return "", fmt.Errorf("unknown_condition")
+	}
+}

--- a/pkg/compiler/sql/sql_condition_test.go
+++ b/pkg/compiler/sql/sql_condition_test.go
@@ -1,0 +1,79 @@
+package sqlcompiler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestCompileCondition(t *testing.T) {
+	logrus.SetLevel(logrus.InfoLevel)
+	//logrus.SetLevel(logrus.TraceLevel)
+
+	tests := []struct {
+		dialect   int
+		input     string
+		expected  string
+		shouldErr bool
+	}{
+		{
+			dialect:   DialectPostgres,
+			input:     `age > 18`,
+			expected:  ``,
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `foobar.qwerty == "there's a single-quote in this string"`,
+			expected:  `(foobar.qwerty = 'there''s a single-quote in this string')`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `subject.nbf < 123 and ctx.description == "string with subject. in it"`,
+			expected:  `(mysqltable.nbf < 123 AND (mysqltable.description = 'string with subject. in it'))`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `not subject.iss == "string with ctx. in it" and ctx.name =~ ".*goofy.*"`,
+			expected:  `((NOT (mysqltable.iss = 'string with ctx. in it')) AND (mysqltable.name ~ '.*goofy.*'))`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["endangered"] == "true"`,
+			expected:  ``, // ``(ctx.tags["endangered"] = 'true')`, // TODO: invalid SQL?
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.id in "tag-manage", "tag-view"`,
+			expected:  ``, // TODO: expect `(ctx.id IN ('tag-manage', 'tag-view'))`,
+			shouldErr: true,
+		},
+	}
+
+	colNameReplacer := strings.NewReplacer(
+		"ctx.", "mysqltable.",
+		"subject.", "mysqltable.",
+	)
+
+	for idx, tst := range tests {
+		where, err := CompileCondition(tst.dialect, tst.input, colNameReplacer)
+		if err != nil && !tst.shouldErr {
+			t.Errorf("Test#%d: failure: unexpected err=%s for input=%s\n",
+				idx, err, tst.input)
+		} else if err == nil && tst.shouldErr {
+			t.Errorf("Test#%d: failure: expected error for input=%s\n", idx, tst.input)
+		} else if err == nil && tst.expected != where {
+			t.Errorf("Test#%d: failure: input=%s expected=%s actual=%s\n",
+				idx, tst.input, tst.expected, where)
+		} else if err != nil && tst.shouldErr {
+			t.Logf("Test#%d: success: expected error and got err=%s\n", idx, err)
+		} else {
+			t.Logf("Test#%d: success: where=%s\n", idx, where)
+		}
+	}
+}


### PR DESCRIPTION
Add new sqlcompiler.CompileCondition() to support converting of obligations into SQL.
Both `make test` and `make demo` pass successfully.

Output of new unit-tests:
```
$ go test -v
=== RUN   TestCompileCondition
    sql_condition_test.go:74: Test#0: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:76: Test#1: success: where=(foobar.qwerty = 'there''s a single-quote in this string')
    sql_condition_test.go:76: Test#2: success: where=(mysqltable.nbf < 123 AND (mysqltable.description = 'string with subject. in it'))
    sql_condition_test.go:76: Test#3: success: where=((NOT (mysqltable.iss = 'string with ctx. in it')) AND (mysqltable.name ~ '.*goofy.*'))
    sql_condition_test.go:74: Test#4: success: expected error and got err=map/array indexing not supported yet: ctx.tags["endangered"]
    sql_condition_test.go:74: Test#5: success: expected error and got err=IN operator not supported yet: (ctx.id in "tag-manage")
--- PASS: TestCompileCondition (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/sql   0.003s
```