### PR TITLE
Add SQL JSONB-predicate support; refactor SQL API to be more adaptable/flexible

### DIFF
--- a/pkg/compiler/sql/sql_condition_test.go
+++ b/pkg/compiler/sql/sql_condition_test.go
@@ -41,7 +41,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `subject.nbf < 123 and ctx.description == "string with subject. in it"`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.nbf < 123 AND (mysqltable.description = 'string with subject. in it'))`,
+			expected:  `(mytable.nbf < 123 AND (mytable.description = 'string with subject. in it'))`,
 			shouldErr: false,
 		},
 		{
@@ -49,7 +49,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `not subject.iss == "string with ctx. in it" and ctx.name =~ ".*goofy.*"`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `((NOT (mysqltable.iss = 'string with ctx. in it')) AND (mysqltable.name ~ '.*goofy.*'))`,
+			expected:  `((NOT (mytable.iss = 'string with ctx. in it')) AND (mytable.name ~ '.*goofy.*'))`,
 			shouldErr: false,
 		},
 		{
@@ -65,7 +65,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["endangered"] == "true"`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.tags->'endangered' = 'true')`,
+			expected:  `(mytable.tags->'endangered' = 'true')`,
 			shouldErr: false,
 		},
 		{
@@ -73,7 +73,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["endangered"] == "true"`,
 			jsonbOp:   JSONBTextOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.tags->>'endangered' = 'true')`,
+			expected:  `(mytable.tags->>'endangered' = 'true')`,
 			shouldErr: false,
 		},
 		{
@@ -81,8 +81,8 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["zero"] == "true"`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  true,
-			expected:  `(mysqltable.tags->zero = 'true')`,
-			shouldErr: false,
+			expected:  ``,
+			shouldErr: true,
 		},
 		{
 			dialect:   DialectPostgres,
@@ -105,7 +105,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["endangered"] == 123`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.tags->'endangered' = 123)`,
+			expected:  `(mytable.tags->'endangered' = 123)`,
 			shouldErr: false,
 		},
 		{
@@ -137,7 +137,7 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["endangered"] == "foo in the foobar"`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.tags->'endangered' = 'bar in the barbar')`,
+			expected:  `(mytable.tags->'endangered' = 'bar in the barbar')`,
 			shouldErr: false,
 		},
 		{
@@ -145,14 +145,14 @@ func TestCompileCondition(t *testing.T) {
 			input:     `ctx.tags["endangered"] == 314159`,
 			jsonbOp:   JSONBObjectOperator,
 			isNumKey:  false,
-			expected:  `(mysqltable.tags->'endangered' = 271828)`,
+			expected:  `(mytable.tags->'endangered' = 271828)`,
 			shouldErr: false,
 		},
 	}
 
 	idNameReplacer := strings.NewReplacer(
-		"ctx.", "mysqltable.",
-		"subject.", "mysqltable.",
+		"ctx.", "mytable.",
+		"subject.", "mytable.",
 	)
 
 	literalReplacer := strings.NewReplacer(

--- a/pkg/compiler/sql/sql_condition_test.go
+++ b/pkg/compiler/sql/sql_condition_test.go
@@ -163,7 +163,7 @@ func TestCompileCondition(t *testing.T) {
 	for idx, tst := range tests {
 		sqlc := NewSQLCompiler(
 			WithDialect(tst.dialect),
-			WithIdentifierReplacer(func(sqlc *SQLCompiler, idParts *lexer.IdentifierParts, id string) (string, error) {
+			WithIdentifierReplacer(func(sqlc *SQLCompiler, swtype string, idParts *lexer.IdentifierParts, id string) (string, error) {
 				if idParts.Field != "tags" {
 					return id, nil
 				}
@@ -171,12 +171,12 @@ func TestCompileCondition(t *testing.T) {
 					WithJSONBOperator(tst.jsonbOp),
 					WithIsNumericKey(tst.isNumKey),
 				)
-				return jsonbReplacer(sqlc, idParts, id)
+				return jsonbReplacer(sqlc, swtype, idParts, id)
 			}),
-			WithIdentifierReplacer(func(sqlc *SQLCompiler, idParts *lexer.IdentifierParts, id string) (string, error) {
+			WithIdentifierReplacer(func(sqlc *SQLCompiler, swtype string, idParts *lexer.IdentifierParts, id string) (string, error) {
 				return idNameReplacer.Replace(id), nil
 			}),
-			WithLiteralReplacer(func(sqlc *SQLCompiler, idParts *lexer.IdentifierParts, s string) (string, error) {
+			WithLiteralReplacer(func(sqlc *SQLCompiler, swtype string, idParts *lexer.IdentifierParts, s string) (string, error) {
 				return literalReplacer.Replace(s), nil
 			}),
 		)

--- a/pkg/compiler/sql/sql_dialect.go
+++ b/pkg/compiler/sql/sql_dialect.go
@@ -1,0 +1,24 @@
+package sqlcompiler
+
+// SQLDialectEnum enumerates SQL dialects
+type SQLDialectEnum int
+
+// SQL dialects
+const (
+	DialectUnknown SQLDialectEnum = iota
+	DialectPostgres
+)
+
+var dialectNames = []string{
+	"DialectUnknown",
+	"DialectPostgres",
+}
+
+// String satisfies fmt.Stringer interface
+func (dia SQLDialectEnum) String() string {
+	dint := int(dia)
+	if dint < 0 || dint >= len(dialectNames) {
+		dint = 0
+	}
+	return dialectNames[dint]
+}

--- a/pkg/compiler/sql/sql_jsonb.go
+++ b/pkg/compiler/sql/sql_jsonb.go
@@ -1,0 +1,86 @@
+package sqlcompiler
+
+// http://www.silota.com/docs/recipes/sql-postgres-json-data-types.html
+// https://kb.objectrocket.com/postgresql/how-to-query-a-postgres-jsonb-column-1433
+// https://www.postgresql.org/message-id/b9341406-f066-ea08-5c0d-1a7404a95df3%40postgrespro.ru
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infobloxopen/seal/pkg/lexer"
+)
+
+// JSONB operators
+const (
+	JSONBObjectOperator = `->`
+	JSONBTextOperator   = `->>`
+	JSONBExistsOperator = `?`
+)
+
+// JSONBReplacer contains JSONB conversion parameters
+type JSONBReplacer struct {
+	JSONBOperator string
+	IsNumericKey  bool
+}
+
+// JSONBOption is option function for JSONB conversion parameters
+type JSONBOption func(jsonb *JSONBReplacer)
+
+// WithJSONBOperator is an option to specify JSONB operator
+func WithJSONBOperator(op string) JSONBOption {
+	return func(jsonb *JSONBReplacer) {
+		jsonb.JSONBOperator = op
+	}
+}
+
+// WithIsNumericKey is an option to specify whether JSONB index key is numeric or not
+func WithIsNumericKey(isNumericKey bool) JSONBOption {
+	return func(jsonb *JSONBReplacer) {
+		jsonb.IsNumericKey = isNumericKey
+	}
+}
+
+// NewJSONBReplacer returns an SQLReplacerFn that replaces indexed-identifiers with Postgres JSONB
+func NewJSONBReplacer(jsonbOpts ...JSONBOption) SQLReplacerFn {
+	jsonb := &JSONBReplacer{
+		JSONBOperator: JSONBObjectOperator,
+		IsNumericKey:  false,
+	}
+
+	for _, opt := range jsonbOpts {
+		opt(jsonb)
+	}
+
+	return func(sqlc *SQLCompiler, idParts *lexer.IdentifierParts, id string) (string, error) {
+		if sqlc.Dialect != DialectPostgres {
+			return "", fmt.Errorf("Dialect %s does not support JSONB conversion of id: %s", sqlc.Dialect, id)
+		}
+
+		if len(idParts.Key) <= 0 {
+			return id, nil
+		}
+
+		var result strings.Builder
+
+		if len(idParts.Table) > 0 {
+			result.WriteString(idParts.Table)
+			result.WriteString(`.`)
+		}
+
+		result.WriteString(idParts.Field)
+		result.WriteString(jsonb.JSONBOperator)
+
+		if !jsonb.IsNumericKey {
+			result.WriteString(`'`)
+		}
+
+		result.WriteString(idParts.Key)
+
+		if !jsonb.IsNumericKey {
+			result.WriteString(`'`)
+		}
+
+		return result.String(), nil
+	}
+}

--- a/pkg/compiler/sql/sql_jsonb.go
+++ b/pkg/compiler/sql/sql_jsonb.go
@@ -53,7 +53,7 @@ func NewJSONBReplacer(jsonbOpts ...JSONBOption) SQLReplacerFn {
 		opt(jsonb)
 	}
 
-	return func(sqlc *SQLCompiler, idParts *lexer.IdentifierParts, id string) (string, error) {
+	return func(sqlc *SQLCompiler, swtype string, idParts *lexer.IdentifierParts, id string) (string, error) {
 		if sqlc.Dialect != DialectPostgres {
 			return id, fmt.Errorf("Dialect %s does not support JSONB conversion of id: %s", sqlc.Dialect, id)
 		}

--- a/pkg/compiler/sql/sql_jsonb_test.go
+++ b/pkg/compiler/sql/sql_jsonb_test.go
@@ -125,7 +125,7 @@ func TestJSONBReplacer(t *testing.T) {
 		)
 		id := tst.input
 		idParts := lexer.SplitIdentifier(id)
-		replaced, err := jsonbReplacer(sqlc, idParts, id)
+		replaced, err := jsonbReplacer(sqlc, "", idParts, id)
 		if err != nil && !tst.shouldErr {
 			t.Errorf("Test#%d: failure: unexpected err=%s for input=%s\n",
 				idx, err, tst.input)

--- a/pkg/compiler/sql/sql_jsonb_test.go
+++ b/pkg/compiler/sql/sql_jsonb_test.go
@@ -1,0 +1,143 @@
+package sqlcompiler
+
+import (
+	"testing"
+
+	"github.com/infobloxopen/seal/pkg/lexer"
+	"github.com/sirupsen/logrus"
+)
+
+func TestJSONBReplacer(t *testing.T) {
+	logrus.SetLevel(logrus.InfoLevel)
+	//logrus.SetLevel(logrus.TraceLevel)
+
+	tests := []struct {
+		dialect   SQLDialectEnum
+		jsonbOp   string
+		isNumKey  bool
+		input     string
+		expected  string
+		shouldErr bool
+	}{
+		{
+			dialect:   DialectUnknown, // Dialect doesn't support JSONB
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  false,
+			expected:  ``,
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[endangered]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  false,
+			expected:  `ctx.tags->'endangered'`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  false,
+			expected:  `ctx.tags->'endangered'`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBTextOperator,
+			isNumKey:  false,
+			expected:  `ctx.tags->>'endangered'`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBExistsOperator,
+			isNumKey:  false,
+			expected:  `ctx.tags?'endangered'`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[0]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  false,
+			expected:  `ctx.tags->'0'`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["0"]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  `ctx.tags->0`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[0]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  `ctx.tags->0`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags["non_numeric_index"]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  ``,
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[non_numeric_index]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  ``,
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[3.14]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  ``,
+			shouldErr: true,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `ctx.tags[-1]`,
+			jsonbOp:   JSONBObjectOperator,
+			isNumKey:  true,
+			expected:  ``,
+			shouldErr: true,
+		},
+	}
+
+	for idx, tst := range tests {
+		sqlc := NewSQLCompiler(WithDialect(tst.dialect))
+		jsonbReplacer := NewJSONBReplacer(
+			WithJSONBOperator(tst.jsonbOp),
+			WithIsNumericKey(tst.isNumKey),
+		)
+		id := tst.input
+		idParts := lexer.SplitIdentifier(id)
+		replaced, err := jsonbReplacer(sqlc, idParts, id)
+		if err != nil && !tst.shouldErr {
+			t.Errorf("Test#%d: failure: unexpected err=%s for input=%s\n",
+				idx, err, tst.input)
+		} else if err == nil && tst.shouldErr {
+			t.Errorf("Test#%d: failure: expected error for input=%s\n", idx, tst.input)
+		} else if err == nil && tst.expected != replaced {
+			t.Errorf("Test#%d: failure: input=%s expected=%s actual=%s\n",
+				idx, tst.input, tst.expected, replaced)
+		} else if err != nil && tst.shouldErr {
+			t.Logf("Test#%d: success: expected error and got err=%s\n", idx, err)
+		} else {
+			t.Logf("Test#%d: success: replaced=%s\n", idx, replaced)
+		}
+	}
+}

--- a/pkg/compiler/sql/sql_option.go
+++ b/pkg/compiler/sql/sql_option.go
@@ -1,0 +1,42 @@
+package sqlcompiler
+
+import "github.com/sirupsen/logrus"
+
+// SQLOption is option function for SQL conversion parameters
+type SQLOption func(sqlc *SQLCompiler)
+
+// WithLogger is an option to specify SQL dialect
+func WithLogger(logger *logrus.Logger) SQLOption {
+	return func(sqlc *SQLCompiler) {
+		sqlc.Logger = logger
+	}
+}
+
+// WithDialect is an option to specify SQL dialect
+func WithDialect(dialect SQLDialectEnum) SQLOption {
+	return func(sqlc *SQLCompiler) {
+		sqlc.Dialect = dialect
+	}
+}
+
+// WithIdentifierReplacer is an option to specify SQLReplacerFn for identifiers.
+// This option can be specified multiple times, and will be executed in the order specified.
+func WithIdentifierReplacer(replacerFn SQLReplacerFn) SQLOption {
+	return func(sqlc *SQLCompiler) {
+		if sqlc.IdentifierReplacers == nil {
+			sqlc.IdentifierReplacers = []SQLReplacerFn{}
+		}
+		sqlc.IdentifierReplacers = append(sqlc.IdentifierReplacers, replacerFn)
+	}
+}
+
+// WithLiteralReplacer is an option to specify SQLReplacerFn for literal values.
+// This option can be specified multiple times, and will be executed in the order specified.
+func WithLiteralReplacer(replacerFn SQLReplacerFn) SQLOption {
+	return func(sqlc *SQLCompiler) {
+		if sqlc.LiteralReplacers == nil {
+			sqlc.LiteralReplacers = []SQLReplacerFn{}
+		}
+		sqlc.LiteralReplacers = append(sqlc.LiteralReplacers, replacerFn)
+	}
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -138,7 +138,9 @@ const IndexedIdentifierChars = `["]`
 
 // IsIndexedIdentifier returns true if id is:
 //   table.field["key"]
+//   table.field[key]
 //   field["key"]
+//   field[key]
 // IsIndexedIdentifier returns false if id is:
 //   table.field
 //   field
@@ -149,8 +151,10 @@ func IsIndexedIdentifier(id string) bool {
 // IdentifierParts holds components of splitted identifiers:
 // Examples of unsplitted identitiers:
 //   table.field["key"]
+//   table.field[key]
 //   table.field
 //   field["key"]
+//   field[key]
 //   field
 type IdentifierParts struct {
 	Table string // component before dot (empty if no dot)

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/infobloxopen/seal/pkg/token"
@@ -278,6 +279,114 @@ func TestNextTokenComment(t *testing.T) {
 				t.Fatalf("tests[%q][%d] - literal wrong. expected=%q, got=%q",
 					tst.name, i, tt.literal, tok.Literal)
 			}
+		}
+	}
+}
+
+func TestIsIndexedIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:     `table.field["key"]`,
+			expected:  true,
+		},
+		{
+			input:     `table.field[key]`,
+			expected:  true,
+		},
+		{
+			input:     `table.field`,
+			expected:  false,
+		},
+		{
+			input:     `field["key"]`,
+			expected:  true,
+		},
+		{
+			input:     `field[key]`,
+			expected:  true,
+		},
+		{
+			input:     `field`,
+			expected:  false,
+		},
+	}
+
+	for idx, tst := range tests {
+		actual := IsIndexedIdentifier(tst.input)
+		if tst.expected != actual {
+			t.Errorf("Test#%d: failure: input=%s expected=%v actual=%v\n",
+				idx, tst.input, tst.expected, actual)
+		} else {
+			t.Logf("Test#%d: success: actual=%v\n", idx, actual)
+		}
+	}
+}
+
+func TestSplitIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *IdentifierParts
+	}{
+		{
+			input:     `table.field["key"]`,
+			expected:  &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:     `table.field[key]`,
+			expected:  &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:     `table.field`,
+			expected:  &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   ``,
+			},
+		},
+		{
+			input:     `field["key"]`,
+			expected:  &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:     `field[key]`,
+			expected:  &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:     `field`,
+			expected:  &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   ``,
+			},
+		},
+	}
+
+	for idx, tst := range tests {
+		actual := SplitIdentifier(tst.input)
+		if !reflect.DeepEqual(actual, tst.expected) {
+			t.Errorf("Test#%d: failure: input=%s expected=%+v actual=%+v\n",
+				idx, tst.input, tst.expected, actual)
+		} else {
+			t.Logf("Test#%d: success: actual=%+v\n", idx, actual)
 		}
 	}
 }


### PR DESCRIPTION
```
$ go test -v
=== RUN   TestCompileCondition
    sql_condition_test.go:193: Test#0: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:195: Test#1: success: where=(foobar.qwerty = 'there''s a single-quote in this string')
    sql_condition_test.go:195: Test#2: success: where=(mytable.nbf < 123 AND (mytable.description = 'string with subject. in it'))
    sql_condition_test.go:195: Test#3: success: where=((NOT (mytable.iss = 'string with ctx. in it')) AND (mytable.name ~ '.*goofy.*'))
    sql_condition_test.go:193: Test#4: success: expected error and got err=Replacer 0 on identifier 'ctx.tags["endangered"]' failed: Dialect DialectUnknown does not support JSONB conversion of id: ctx.tags["endangered"]
    sql_condition_test.go:195: Test#5: success: where=(mytable.tags->'endangered' = 'true')
    sql_condition_test.go:195: Test#6: success: where=(mytable.tags->>'endangered' = 'true')
    sql_condition_test.go:193: Test#7: success: expected error and got err=Replacer 0 on identifier 'ctx.tags["zero"]' failed: Index key is not unsigned-integer: ctx.tags["zero"]
    sql_condition_test.go:193: Test#8: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:193: Test#9: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:195: Test#10: success: where=(mytable.tags->'endangered' = 123)
    sql_condition_test.go:193: Test#11: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:193: Test#12: success: expected error and got err=Do not know how to SQL-convert indexed-identifier: mytable.tagz["endangered"]
    sql_condition_test.go:193: Test#13: success: expected error and got err=IN operator not supported yet: (ctx.id in "tag-manage")
    sql_condition_test.go:195: Test#14: success: where=(mytable.tags->'endangered' = 'bar in the barbar')
    sql_condition_test.go:195: Test#15: success: where=(mytable.tags->'endangered' = 271828)
--- PASS: TestCompileCondition (0.00s)
=== RUN   TestJSONBReplacer
    sql_jsonb_test.go:138: Test#0: success: expected error and got err=Dialect DialectUnknown does not support JSONB conversion of id: ctx.tags["endangered"]
    sql_jsonb_test.go:140: Test#1: success: replaced=ctx.tags->'endangered'
    sql_jsonb_test.go:140: Test#2: success: replaced=ctx.tags->'endangered'
    sql_jsonb_test.go:140: Test#3: success: replaced=ctx.tags->>'endangered'
    sql_jsonb_test.go:140: Test#4: success: replaced=ctx.tags?'endangered'
    sql_jsonb_test.go:140: Test#5: success: replaced=ctx.tags->'0'
    sql_jsonb_test.go:140: Test#6: success: replaced=ctx.tags->0
    sql_jsonb_test.go:140: Test#7: success: replaced=ctx.tags->0
    sql_jsonb_test.go:138: Test#8: success: expected error and got err=Index key is not unsigned-integer: ctx.tags["non_numeric_index"]
    sql_jsonb_test.go:138: Test#9: success: expected error and got err=Index key is not unsigned-integer: ctx.tags[non_numeric_index]
    sql_jsonb_test.go:138: Test#10: success: expected error and got err=Index key is not unsigned-integer: ctx.tags[3.14]
    sql_jsonb_test.go:138: Test#11: success: expected error and got err=Index key is not unsigned-integer: ctx.tags[-1]
--- PASS: TestJSONBReplacer (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/sql   0.006s
```

```
$ go test -v
=== RUN   TestNextToken
--- PASS: TestNextToken (0.00s)
=== RUN   TestContextToken
--- PASS: TestContextToken (0.00s)
=== RUN   TestNextTokenComment
--- PASS: TestNextTokenComment (0.00s)
=== RUN   TestIsIndexedIdentifier
    lexer_test.go:322: Test#0: success: actual=true
    lexer_test.go:322: Test#1: success: actual=true
    lexer_test.go:322: Test#2: success: actual=false
    lexer_test.go:322: Test#3: success: actual=true
    lexer_test.go:322: Test#4: success: actual=true
    lexer_test.go:322: Test#5: success: actual=false
--- PASS: TestIsIndexedIdentifier (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/lexer  0.002s
```