### PR TITLE
Refactor SQL-API to use Type/Property mappers; Add SQL-JSONB-predicate support

### DIFF
--- a/pkg/compiler/sql/sql_dialect.go
+++ b/pkg/compiler/sql/sql_dialect.go
@@ -1,0 +1,24 @@
+package sqlcompiler
+
+// SQLDialectEnum enumerates SQL dialects
+type SQLDialectEnum int
+
+// SQL dialects
+const (
+	DialectUnknown SQLDialectEnum = iota
+	DialectPostgres
+)
+
+var dialectNames = []string{
+	"DialectUnknown",
+	"DialectPostgres",
+}
+
+// String satisfies fmt.Stringer interface
+func (dia SQLDialectEnum) String() string {
+	dint := int(dia)
+	if dint < 0 || dint >= len(dialectNames) {
+		dint = 0
+	}
+	return dialectNames[dint]
+}

--- a/pkg/compiler/sql/sql_typemapper.go
+++ b/pkg/compiler/sql/sql_typemapper.go
@@ -1,0 +1,204 @@
+package sqlcompiler
+
+// http://www.silota.com/docs/recipes/sql-postgres-json-data-types.html
+// https://kb.objectrocket.com/postgresql/how-to-query-a-postgres-jsonb-column-1433
+// https://www.postgresql.org/message-id/b9341406-f066-ea08-5c0d-1a7404a95df3%40postgrespro.ru
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/infobloxopen/seal/pkg/lexer"
+)
+
+// JSONB operators
+const (
+	JSONBObjectOperator = `->`
+	JSONBTextOperator   = `->>`
+	JSONBExistsOperator = `?`
+)
+
+// PropertyMapper contains mapping parameters for Swagger properties
+type PropertyMapper struct {
+	TypeMapper      *TypeMapper
+	SEALProperty    string
+	SQLColumn       string
+	JSONBOperator   string
+	JSONBIntKeyFlag bool
+}
+
+// NewPropertyMapper returns new instance of PropertyMapper for specified property 'name'.
+// The specified property can be "*" to allow matching of any property name,
+// as long as there is no specific match.
+// Note that these two statements are equivalent:
+//     pmpr := NewPropertyMapper("tags")
+//     pmpr := NewPropertyMapper("").WithSEALProperty("tags")
+func NewPropertyMapper(name string) *PropertyMapper {
+	pmpr := &PropertyMapper{
+		SEALProperty:    name,
+		SQLColumn:       name,
+		JSONBOperator:   JSONBObjectOperator,
+		JSONBIntKeyFlag: false,
+	}
+	return pmpr
+}
+
+// WithSEALProperty specifies the property name, overriding the previously set name.
+// Property name can be "*" to match any property.
+// However a PropertyMapper with a more specific match takes precedence over "*".
+func (pmpr *PropertyMapper) WithSEALProperty(name string) *PropertyMapper {
+	pmpr.SEALProperty = name
+	return pmpr
+}
+
+// ToSQLColumn specifies what column name the property should map to.
+// If column name specified is "*", then the column name will be whatever
+// the input property name is that matched this PropertyMapper.
+// For example, if ToSQLColumn("*") is specified and the input property name
+// is "tags", then the column name in the converted SQL will be "tags".
+func (pmpr *PropertyMapper) ToSQLColumn(name string) *PropertyMapper {
+	pmpr.SQLColumn = name
+	return pmpr
+}
+
+// UseJSONBOperator specifies the JSONB operator to use for converting indexed properties.
+// The default is JSONBObjectOperator (ie: "->").
+// Only the DialectPostgres SQL dialect supports JSONB conversion.
+func (pmpr *PropertyMapper) UseJSONBOperator(op string) *PropertyMapper {
+	pmpr.JSONBOperator = op
+	return pmpr
+}
+
+// UseJSONBIntKeyFlag specifies the JSONB integer index flag to use for converting indexed properties.
+// The default is false.
+// Only the DialectPostgres SQL dialect supports JSONB conversion.
+func (pmpr *PropertyMapper) UseJSONBIntKeyFlag(flag bool) *PropertyMapper {
+	pmpr.JSONBIntKeyFlag = flag
+	return pmpr
+}
+
+// TypeMapper contains mapping parameters for Swagger types
+type TypeMapper struct {
+	SQLCompiler *SQLCompiler
+	SwaggerType string
+	SQLTable    string
+	PptyMappers map[string]*PropertyMapper
+}
+
+// NewTypeMapper returns new instance of NewTypeMapper for specified swagger type 'name'.
+// The specified type can be "app.*" to allow matching of any application-specific swagger type name,
+// as long as there is no specific match.
+// Note that these two statements are equivalent:
+//     tmpr := NewTypeMapper("ddi.ipam")
+//     tmpr := NewTypeMapper("").WithSwaggerType("ddi.ipam")
+func NewTypeMapper(name string) *TypeMapper {
+	tmpr := &TypeMapper{
+		SwaggerType: name,
+		SQLTable:    name,
+		PptyMappers: map[string]*PropertyMapper{},
+	}
+	return tmpr
+}
+
+// WithSwaggerType specifies the swagger type name, overriding the previously set name.
+// Swagger type name can be "app.*" to match any application-specific swagger type.
+// However a TypeMapper with a more specific match takes precedence over "app.*".
+func (tmpr *TypeMapper) WithSwaggerType(name string) *TypeMapper {
+	tmpr.SwaggerType = name
+	return tmpr
+}
+
+// ToSQLTable specifies what table name the swagger type should map to.
+// If table name specified is "*", then the table name will be whatever
+// the input swagger type name is that matched this TypeMapper.
+// For example, if ToSQLTable("*") is specified and the input swagger type name
+// is "ddi.ipam", then the table name in the converted SQL will be "ipam".
+func (tmpr *TypeMapper) ToSQLTable(name string) *TypeMapper {
+	tmpr.SQLTable = name
+	return tmpr
+}
+
+// WithPropertyMapper adds PropertyMapper to this TypeMapper.
+// PropertyMapper must be name-unique within TypeMapper.
+// When adding multiple PropertyMapper with the same name, the most recent add wins.
+func (tmpr *TypeMapper) WithPropertyMapper(pmpr *PropertyMapper) *TypeMapper {
+	tmpr.PptyMappers[pmpr.SEALProperty] = pmpr
+	pmpr.TypeMapper = tmpr
+	return tmpr
+}
+
+// ReplaceIdentifier performs type and property SQL mapping on the given SEAL identifier "id".
+// "swtype" is the swagger type for this identifier.
+// If there is no mapping that matches "swtype" or "id", then original "id" is returned with nil error.
+// Always returns original id on error.
+//
+// For example, TypeMapper("ddi.ipam") will match swtype "ddi.ipam".
+// TypeMapper("ddi.*") will also match swtype "ddi.ipam" if there is no TypeMapper("ddi.ipam").
+//
+// For example, PropertyMapper("tags") will match id "ctx.tags".
+// PropertyMapper("*") will also match id "ctx.tags" if there is no PropertyMapper("tags").
+func (tmpr *TypeMapper) ReplaceIdentifier(swtype string, id string) (string, error) {
+	swParts := lexer.SplitSwaggerType(swtype)
+	if swtype != tmpr.SwaggerType {
+		savedType := swParts.Type
+		swParts.Type = `*`
+		if swParts.String() != tmpr.SwaggerType {
+			return id, nil
+		}
+		swParts.Type = savedType
+	}
+
+	idParts := lexer.SplitIdentifier(id)
+	pmpr, foundPpty := tmpr.PptyMappers[idParts.Field]
+	if !foundPpty {
+		pmpr, foundPpty = tmpr.PptyMappers[`*`]
+		if !foundPpty {
+			return id, nil
+		}
+	}
+
+	if len(idParts.Key) > 0 {
+		if tmpr.SQLCompiler.Dialect != DialectPostgres {
+			return id, fmt.Errorf("SQL dialect %s does not support JSONB conversion of type/id: %s/%s",
+				tmpr.SQLCompiler.Dialect, swtype, id)
+		} else if pmpr.JSONBIntKeyFlag {
+			_, err := strconv.ParseUint(idParts.Key, 10, 0)
+			if err != nil {
+				return id, fmt.Errorf("JSONB index key is not unsigned-integer for type/id: %s/%s", swtype, id)
+			}
+		}
+	}
+
+	var newID strings.Builder
+
+	if tmpr.SQLTable == `*` {
+		newID.WriteString(swParts.Type)
+	} else {
+		newID.WriteString(tmpr.SQLTable)
+	}
+
+	newID.WriteString(`.`)
+
+	if pmpr.SQLColumn == `*` {
+		newID.WriteString(idParts.Field)
+	} else {
+		newID.WriteString(pmpr.SQLColumn)
+	}
+
+	if len(idParts.Key) > 0 {
+		newID.WriteString(pmpr.JSONBOperator)
+
+		if !pmpr.JSONBIntKeyFlag {
+			newID.WriteString(`'`)
+		}
+
+		newID.WriteString(idParts.Key)
+
+		if !pmpr.JSONBIntKeyFlag {
+			newID.WriteString(`'`)
+		}
+	}
+
+	return newID.String(), nil
+}

--- a/pkg/compiler/sql/sql_typemapper_test.go
+++ b/pkg/compiler/sql/sql_typemapper_test.go
@@ -1,0 +1,204 @@
+package sqlcompiler
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestTypeMapper(t *testing.T) {
+	logrus.SetLevel(logrus.InfoLevel)
+	//logrus.SetLevel(logrus.TraceLevel)
+
+	tests := []struct {
+		dialect   SQLDialectEnum
+		swtype    string
+		jsonbOp   string
+		intFlag   bool
+		input     string
+		expected  string
+		shouldErr bool
+		asterisk  bool
+	}{
+		{
+			dialect:   DialectUnknown, // Dialect doesn't support JSONB
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  ``,
+			shouldErr: true,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.address`, // unmatched swagger type
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `ctx.tags["endangered"]`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.taggs["endangered"]`, // unmatched swagger property
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `ctx.taggs["endangered"]`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.taggs["endangered"]`, // swagger property matches "*"
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `profile.taggs->'endangered'`,
+			shouldErr: false,
+			asterisk:  true,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[endangered]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `profile.tagz->'endangered'`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `profile.tagz->'endangered'`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBTextOperator,
+			intFlag:   false,
+			expected:  `profile.tagz->>'endangered'`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["endangered"]`,
+			jsonbOp:   JSONBExistsOperator,
+			intFlag:   false,
+			expected:  `profile.tagz?'endangered'`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[0]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  `profile.tagz->'0'`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["0"]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  `profile.tagz->0`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[0]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  `profile.tagz->0`,
+			shouldErr: false,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags["non_numeric_index"]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  ``,
+			shouldErr: true,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[non_numeric_index]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  ``,
+			shouldErr: true,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[3.14]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  ``,
+			shouldErr: true,
+			asterisk:  false,
+		},
+		{
+			dialect:   DialectPostgres,
+			swtype:    `contacts.profile`,
+			input:     `ctx.tags[-1]`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   true,
+			expected:  ``,
+			shouldErr: true,
+			asterisk:  false,
+		},
+	}
+
+	for idx, tst := range tests {
+		tmpr := NewTypeMapper("contacts.profile").ToSQLTable("profile").
+			WithPropertyMapper(NewPropertyMapper("tags").ToSQLColumn("tagz").
+				UseJSONBOperator(tst.jsonbOp).
+				UseJSONBIntKeyFlag(tst.intFlag),
+			)
+		if tst.asterisk {
+			tmpr = tmpr.WithPropertyMapper(NewPropertyMapper("*").ToSQLColumn("*").
+				UseJSONBOperator(tst.jsonbOp).
+				UseJSONBIntKeyFlag(tst.intFlag),
+			)
+		}
+		_ = NewSQLCompiler().WithDialect(tst.dialect).WithTypeMapper(tmpr)
+		id := tst.input
+		replaced, err := tmpr.ReplaceIdentifier(tst.swtype, id)
+		if err != nil && !tst.shouldErr {
+			t.Errorf("Test#%d: failure: unexpected err=%s for input=%s\n",
+				idx, err, tst.input)
+		} else if err == nil && tst.shouldErr {
+			t.Errorf("Test#%d: failure: expected error for input=%s\n", idx, tst.input)
+		} else if err == nil && tst.expected != replaced {
+			t.Errorf("Test#%d: failure: input=%s expected=%s actual=%s\n",
+				idx, tst.input, tst.expected, replaced)
+		} else if err != nil && tst.shouldErr {
+			t.Logf("Test#%d: success: expected error and got err=%s\n", idx, err)
+		} else {
+			t.Logf("Test#%d: success: replaced=%s\n", idx, replaced)
+		}
+	}
+}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/infobloxopen/seal/pkg/token"
@@ -278,6 +279,114 @@ func TestNextTokenComment(t *testing.T) {
 				t.Fatalf("tests[%q][%d] - literal wrong. expected=%q, got=%q",
 					tst.name, i, tt.literal, tok.Literal)
 			}
+		}
+	}
+}
+
+func TestIsIndexedIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    `table.field["key"]`,
+			expected: true,
+		},
+		{
+			input:    `table.field[key]`,
+			expected: true,
+		},
+		{
+			input:    `table.field`,
+			expected: false,
+		},
+		{
+			input:    `field["key"]`,
+			expected: true,
+		},
+		{
+			input:    `field[key]`,
+			expected: true,
+		},
+		{
+			input:    `field`,
+			expected: false,
+		},
+	}
+
+	for idx, tst := range tests {
+		actual := IsIndexedIdentifier(tst.input)
+		if tst.expected != actual {
+			t.Errorf("Test#%d: failure: input=%s expected=%v actual=%v\n",
+				idx, tst.input, tst.expected, actual)
+		} else {
+			t.Logf("Test#%d: success: actual=%v\n", idx, actual)
+		}
+	}
+}
+
+func TestSplitIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *IdentifierParts
+	}{
+		{
+			input:    `table.field["key"]`,
+			expected: &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:    `table.field[key]`,
+			expected: &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:    `table.field`,
+			expected: &IdentifierParts{
+				Table: `table`,
+				Field: `field`,
+				Key:   ``,
+			},
+		},
+		{
+			input:    `field["key"]`,
+			expected: &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:    `field[key]`,
+			expected: &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   `key`,
+			},
+		},
+		{
+			input:    `field`,
+			expected: &IdentifierParts{
+				Table: ``,
+				Field: `field`,
+				Key:   ``,
+			},
+		},
+	}
+
+	for idx, tst := range tests {
+		actual := SplitIdentifier(tst.input)
+		if !reflect.DeepEqual(actual, tst.expected) {
+			t.Errorf("Test#%d: failure: input=%s expected=%+v actual=%+v\n",
+				idx, tst.input, tst.expected, actual)
+		} else {
+			t.Logf("Test#%d: success: actual=%+v\n", idx, actual)
 		}
 	}
 }


### PR DESCRIPTION
Replaces https://github.com/infobloxopen/seal/pull/132 with more developer-friendly SQL API (as requested by @daniel-garcia )

`make test demo` passes successfully.  Pertinent unit-tests shown:

```
$ go test -v
=== RUN   TestNextToken
--- PASS: TestNextToken (0.00s)
=== RUN   TestContextToken
--- PASS: TestContextToken (0.00s)
=== RUN   TestNextTokenComment
--- PASS: TestNextTokenComment (0.00s)
=== RUN   TestIsIndexedIdentifier
    lexer_test.go:323: Test#0: success: actual=true
    lexer_test.go:323: Test#1: success: actual=true
    lexer_test.go:323: Test#2: success: actual=false
    lexer_test.go:323: Test#3: success: actual=true
    lexer_test.go:323: Test#4: success: actual=true
    lexer_test.go:323: Test#5: success: actual=false
--- PASS: TestIsIndexedIdentifier (0.00s)
=== RUN   TestSplitIdentifier
    lexer_test.go:389: Test#0: success: actual=&{Table:table Field:field Key:key}
    lexer_test.go:389: Test#1: success: actual=&{Table:table Field:field Key:key}
    lexer_test.go:389: Test#2: success: actual=&{Table:table Field:field Key:}
    lexer_test.go:389: Test#3: success: actual=&{Table: Field:field Key:key}
    lexer_test.go:389: Test#4: success: actual=&{Table: Field:field Key:key}
    lexer_test.go:389: Test#5: success: actual=&{Table: Field:field Key:}
--- PASS: TestSplitIdentifier (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/lexer  0.003s
```

```
$ go test -v
=== RUN   TestCompileCondition
    sql_condition_test.go:186: Test#0: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:188: Test#1: success: where=(foobar.qwerty = 'there''s a single-quote in this string')
    sql_condition_test.go:188: Test#2: success: where=(profile.nbf < 123 AND (profile.description = 'string with subject. in it'))
    sql_condition_test.go:186: Test#3: success: expected error and got err=SQL dialect DialectUnknown does not know how to convert regexp-match: ctx.name =~ ".*goofy.*"
    sql_condition_test.go:188: Test#4: success: where=((NOT (profile.iss = 'string with ctx. in it')) AND (profile.name ~ '.*goofy.*'))
    sql_condition_test.go:186: Test#5: success: expected error and got err=ReplaceIdentifier 'ctx.tags["endangered"]' failed: SQL dialect DialectUnknown does not support JSONB conversion of type/id: contacts.profile/ctx.tags["endangered"]
    sql_condition_test.go:188: Test#6: success: where=(profile.tagz->'endangered' = 'true')
    sql_condition_test.go:188: Test#7: success: where=(profile.tagz->>'endangered' = 'true')
    sql_condition_test.go:186: Test#8: success: expected error and got err=ReplaceIdentifier 'ctx.tags["zero"]' failed: JSONB index key is not unsigned-integer for type/id: contacts.profile/ctx.tags["zero"]
    sql_condition_test.go:186: Test#9: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:186: Test#10: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:188: Test#11: success: where=(profile.tagz->'endangered' = 123)
    sql_condition_test.go:186: Test#12: success: expected error and got err=no prefix condition parse function for IDENT found
    sql_condition_test.go:188: Test#13: success: where=(address.labels->'endangered' = 'true')
    sql_condition_test.go:188: Test#14: success: where=(ipam.notes->'color' = 'true')
    sql_condition_test.go:186: Test#15: success: expected error and got err=SQL-conversion of IN operator not supported yet: (ctx.id in "tag-manage")
--- PASS: TestCompileCondition (0.00s)
=== RUN   TestTypeMapper
    sql_typemapper_test.go:199: Test#0: success: expected error and got err=SQL dialect DialectUnknown does not support JSONB conversion of type/id: contacts.profile/ctx.tags["endangered"]
    sql_typemapper_test.go:201: Test#1: success: replaced=ctx.tags["endangered"]
    sql_typemapper_test.go:201: Test#2: success: replaced=ctx.taggs["endangered"]
    sql_typemapper_test.go:201: Test#3: success: replaced=profile.taggs->'endangered'
    sql_typemapper_test.go:201: Test#4: success: replaced=profile.tagz->'endangered'
    sql_typemapper_test.go:201: Test#5: success: replaced=profile.tagz->'endangered'
    sql_typemapper_test.go:201: Test#6: success: replaced=profile.tagz->>'endangered'
    sql_typemapper_test.go:201: Test#7: success: replaced=profile.tagz?'endangered'
    sql_typemapper_test.go:201: Test#8: success: replaced=profile.tagz->'0'
    sql_typemapper_test.go:201: Test#9: success: replaced=profile.tagz->0
    sql_typemapper_test.go:201: Test#10: success: replaced=profile.tagz->0
    sql_typemapper_test.go:199: Test#11: success: expected error and got err=JSONB index key is not unsigned-integer for type/id: contacts.profile/ctx.tags["non_numeric_index"]
    sql_typemapper_test.go:199: Test#12: success: expected error and got err=JSONB index key is not unsigned-integer for type/id: contacts.profile/ctx.tags[non_numeric_index]
    sql_typemapper_test.go:199: Test#13: success: expected error and got err=JSONB index key is not unsigned-integer for type/id: contacts.profile/ctx.tags[3.14]
    sql_typemapper_test.go:199: Test#14: success: expected error and got err=JSONB index key is not unsigned-integer for type/id: contacts.profile/ctx.tags[-1]
--- PASS: TestTypeMapper (0.00s)
PASS
ok      github.com/infobloxopen/seal/pkg/compiler/sql   0.006s
```