### PR TITLE
Add array-literal support for in-operator

### DIFF
--- a/docs/source/examples/petstore/petstore.all.rego
+++ b/docs/source/examples/petstore/petstore.all.rego
@@ -97,7 +97,15 @@ base_verbs := {
 deny {
 	seal_list_contains(base_verbs[input.type].deliver, input.verb)
 	re_match(`petstore.order`, input.type)
-	seal_list_contains(seal_subject.groups, `boss`)
+	seal_list_contains(seal_subject.groups, "boss")
+}
+
+allow {
+	seal_list_contains(base_verbs[input.type].buy, input.verb)
+	re_match(`petstore.pet`, input.type)
+
+	some i
+	seal_list_contains(["half-breed", "mongrel", "mutt"], input.ctx[i].breed)
 }
 
 deny {
@@ -179,15 +187,15 @@ deny {
 	seal_list_contains(seal_subject.groups, `fussy`)
 	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
-	not line13_not1_cnd
-	not line13_not2_cnd
+	not line14_not1_cnd
+	not line14_not2_cnd
 }
 
 allow {
 	seal_list_contains(seal_subject.groups, `fussy`)
 	seal_list_contains(base_verbs[input.type].buy, input.verb)
 	re_match(`petstore.pet`, input.type)
-	not line14_not1_cnd
+	not line15_not1_cnd
 }
 
 allow {
@@ -196,7 +204,7 @@ allow {
 	re_match(`petstore.pet`, input.type)
 
 	some i
-	not line15_not1_cnd
+	not line16_not1_cnd
 	input.ctx[i].potty_trained
 }
 
@@ -291,30 +299,30 @@ allow {
 	input.ctx[i].t4gs["0"] == "zer0"
 }
 
-line13_not1_cnd {
-	some i
-	input.ctx[i].neutered
-}
-
-line13_not2_cnd {
-	some i
-	input.ctx[i].potty_trained
-}
-
 line14_not1_cnd {
 	some i
 	input.ctx[i].neutered
+}
+
+line14_not2_cnd {
+	some i
 	input.ctx[i].potty_trained
 }
 
 line15_not1_cnd {
 	some i
 	input.ctx[i].neutered
+	input.ctx[i].potty_trained
+}
+
+line16_not1_cnd {
+	some i
+	input.ctx[i].neutered
 }
 
 obligations := {
-	`stmt20`: [`type:petstore.order; (ctx.marketplace != "amazon")`],
-	`stmt21`: [`type:petstore.user; ((ctx.occupation != "unemployed") and (ctx.salary > 200000))`],
+	`stmt21`: [`type:petstore.order; (ctx.marketplace != "amazon")`],
+	`stmt22`: [`type:petstore.user; ((ctx.occupation != "unemployed") and (ctx.salary > 200000))`],
 }
 
 # rego functions defined by seal

--- a/docs/source/examples/petstore/petstore.all.rego.compiled
+++ b/docs/source/examples/petstore/petstore.all.rego.compiled
@@ -113,7 +113,15 @@ base_verbs := {
 deny {
     seal_list_contains(base_verbs[input.type][`deliver`], input.verb)
     re_match(`petstore.order`, input.type)
-    seal_list_contains(seal_subject.groups, `boss`)
+    seal_list_contains(seal_subject.groups, "boss")
+}
+
+allow {
+    seal_list_contains(base_verbs[input.type][`buy`], input.verb)
+    re_match(`petstore.pet`, input.type)
+
+    some i
+    seal_list_contains(["half-breed","mongrel","mutt",], input.ctx[i]["breed"])
 }
 
 deny {
@@ -195,15 +203,15 @@ deny {
     seal_list_contains(seal_subject.groups, `fussy`)
     seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
-    not line13_not1_cnd
-    not line13_not2_cnd
+    not line14_not1_cnd
+    not line14_not2_cnd
 }
 
 allow {
     seal_list_contains(seal_subject.groups, `fussy`)
     seal_list_contains(base_verbs[input.type][`buy`], input.verb)
     re_match(`petstore.pet`, input.type)
-    not line14_not1_cnd
+    not line15_not1_cnd
 }
 
 allow {
@@ -212,7 +220,7 @@ allow {
     re_match(`petstore.pet`, input.type)
 
     some i
-    not line15_not1_cnd
+    not line16_not1_cnd
     input.ctx[i]["potty_trained"]
 }
 
@@ -307,32 +315,32 @@ allow {
     input.ctx[i]["t4gs"]["0"] == "zer0"
 }
 
-line13_not1_cnd {
-    some i
-    input.ctx[i]["neutered"]
-}
-
-line13_not2_cnd {
-    some i
-    input.ctx[i]["potty_trained"]
-}
-
 line14_not1_cnd {
     some i
     input.ctx[i]["neutered"]
+}
+
+line14_not2_cnd {
+    some i
     input.ctx[i]["potty_trained"]
 }
 
 line15_not1_cnd {
     some i
     input.ctx[i]["neutered"]
+    input.ctx[i]["potty_trained"]
+}
+
+line16_not1_cnd {
+    some i
+    input.ctx[i]["neutered"]
 }
 
 obligations := {
-    `stmt20`: [
+    `stmt21`: [
         `type:petstore.order; (ctx.marketplace != "amazon")`,
     ],
-    `stmt21`: [
+    `stmt22`: [
         `type:petstore.user; ((ctx.occupation != "unemployed") and (ctx.salary > 200000))`,
     ],
 }

--- a/docs/source/examples/petstore/petstore.all.seal
+++ b/docs/source/examples/petstore/petstore.all.seal
@@ -1,5 +1,6 @@
 #in operator
 deny to deliver petstore.order where "boss" in subject.groups;
+allow to buy petstore.pet where ctx.breed in ["half-breed","mongrel","mutt"];
 
 #context
 context {

--- a/docs/source/examples/petstore/petstore.all.test.rego
+++ b/docs/source/examples/petstore/petstore.all.test.rego
@@ -31,6 +31,29 @@ test_in_negative {
 	not deny with input as in
 }
 
+#allow to buy petstore.pet where ctx.breed in ["half-breed","mongrel","mutt"];
+test_in_operator_array_literal_positive {
+	in := {
+		"type": "petstore.pet",
+		"verb": "buy",
+		"jwt": sealtest_jwt_encode_sign({"groups": ["in_operator_array_literal_positive"]}),
+		"ctx": [{"breed": "mongrel"}],
+	}
+
+	allow with input as in
+}
+
+test_in_operator_array_literal_negative {
+	in := {
+		"type": "petstore.pet",
+		"verb": "buy",
+		"jwt": sealtest_jwt_encode_sign({"groups": ["in_operator_array_literal_positive"]}),
+		"ctx": [{"breed": "snoopy"}],
+	}
+
+	not allow with input as in
+}
+
 #allow subject group not_operator_precedence to buy petstore.pet where not ctx.neutered and ctx.potty_trained;
 test_not_operator_precedence_positive {
 	in := {

--- a/docs/source/grammar/grammar.md
+++ b/docs/source/grammar/grammar.md
@@ -214,6 +214,7 @@ Where Clause consists of the following in EBNF grammar:
                                 | <relational-expression> <= <not-expression>
                                 | <relational-expression> >= <not-expression>
                                 | <relational-expression> in <field-access>
+                                | <relational-expression> in <array-literal>
 
 <not-expression>              ::= <not-expression> | not <primary>
 
@@ -225,6 +226,9 @@ Where Clause consists of the following in EBNF grammar:
 <identifier-char>             ::= <letter> | <digit> | "_"
 
 ; ==== common dependencies section
+<array-literal>               ::= "[" <array-items> "]"
+<array-items>                 ::= <literal> | <array-items> "," <literal>
+
 <literal>                     ::= <integer> | '"' <quoted> '"'
 
 <integer>                     ::= <integer> | <digit> <integer>

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/infobloxopen/seal/pkg/token"
 	"github.com/infobloxopen/seal/pkg/types"
@@ -91,6 +92,29 @@ func (slf *IntegerLiteral) conditionNode()       {}
 func (slf *IntegerLiteral) TokenLiteral() string { return slf.Token.Literal }
 func (slf *IntegerLiteral) String() string       { return slf.Token.Literal }
 func (slf *IntegerLiteral) GetTypes() []*Identifier {
+	return []*Identifier{}
+}
+
+type ArrayLiteral struct {
+	Token token.Token
+	Items []Condition
+}
+
+func (slf *ArrayLiteral) conditionNode()       {}
+func (slf *ArrayLiteral) TokenLiteral() string {
+	var bldr strings.Builder
+	bldr.WriteString(`[`)
+	for _, it := range slf.Items {
+		bldr.WriteString(it.String())
+		bldr.WriteString(`,`)
+	}
+	bldr.WriteString(`]`)
+	return bldr.String()
+}
+func (slf *ArrayLiteral) String() string {
+	return slf.TokenLiteral()
+}
+func (slf *ArrayLiteral) GetTypes() []*Identifier {
 	return []*Identifier{}
 }
 

--- a/pkg/compiler/policy_compiler.go
+++ b/pkg/compiler/policy_compiler.go
@@ -48,6 +48,11 @@ func NewPolicyCompiler(backend string, swaggerTypes ...string) (*PolicyCompiler,
 	return cmplr, nil
 }
 
+// BackendCompiler returns the backend compiler instance
+func (rc *PolicyCompiler) BackendCompiler() Compiler {
+	return rc.cmplr
+}
+
 func (rc *PolicyCompiler) mergeSwaggers(swaggerTypes ...string) (string, error) {
 	var rSw *openapi3.T
 

--- a/pkg/compiler/rego/rego_test.go
+++ b/pkg/compiler/rego/rego_test.go
@@ -157,12 +157,174 @@ allow {
 obligations := {
 }` + "\n" + CompiledRegoHelpers,
 		},
+		{
+			name: `in-operator: allow subject user foo to manage petstore.pet where ctx.age in [1,"2"];`,
+			pkg:  "foo",
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: token.IDENT, Literal: "allow"},
+						Action: &ast.Identifier{
+							Token: token.Token{Type: token.IDENT, Literal: "allow"},
+							Value: "allow",
+						},
+						Subject: &ast.SubjectUser{Token: token.SUBJECT, User: "foo"},
+						Verb: &ast.Identifier{
+							Token: token.Token{Type: token.IDENT, Literal: "manage"},
+							Value: "manage",
+						},
+						TypePattern: &ast.Identifier{
+							Token: token.Token{Type: token.TYPE_PATTERN, Literal: "petstore.pet"},
+							Value: "petstore.pet",
+						},
+						WhereClause: &ast.WhereClause{
+							Token: token.Token{Type: token.WHERE, Literal: "where"},
+							Condition: &ast.InfixCondition{
+								Token: token.Token{Type: token.OP_IN, Literal: "in"},
+								Left: &ast.Identifier{
+									Token: token.Token{Type: token.IDENT, Literal: "ctx.age"},
+									Value: "ctx.age",
+								},
+								Operator: "in",
+								Right: &ast.ArrayLiteral{
+									Token: token.Token{Type: token.OPEN_SQ, Literal: "["},
+									Items: []ast.Condition{
+										&ast.IntegerLiteral{
+											Token: token.Token{Type: token.INT, Literal: "1"},
+											Value: 1,
+										},
+										&ast.Identifier{
+											Token: token.Token{Type: token.LITERAL, Literal: "2"},
+											Value: "2",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+package foo
+
+default allow = false
+default deny = false
+
+base_verbs := {
+}
+
+allow {
+    seal_subject.sub == ` + "`foo`" + `
+    seal_list_contains(base_verbs[input.type][` + "`manage`" + `], input.verb)
+    re_match(` + "`petstore.pet`" + `, input.type)
+
+    some i
+    seal_list_contains([1,"2",], input.ctx[i]["age"])
+}
+
+obligations := {
+}` + "\n" + CompiledRegoHelpers,
+		},
 	}
 
 	c, err := New()
 	if err != nil {
 		t.Fatalf("did not expect error creating backend - error: %s", err)
 	}
+	var emptySwaggerTypes []types.Type
+	for idx, tst := range tests {
+		actual, err := c.Compile(tst.pkg, tst.pols, emptySwaggerTypes)
+		if tst.err == nil && err != nil || tst.err != nil && err == nil {
+			t.Fatalf("expected error state not returned for tst #%d tst:%s.\n  expected: %s  actual: %s",
+				idx+1, tst.name, tst.err, err)
+		}
+
+		if tst.expected != actual {
+			t.Fatalf("expected output not returned for tst #%d %s.\n  EXPECTED: %s\n  ACTUAL: %s\n",
+				idx, tst.name, tst.expected, actual)
+		}
+
+		if len(tst.expected) > 0 {
+			t.Logf("%s", tst.name)
+			t.Logf("%s language output generated:\n%s", Language, tst.expected)
+		}
+	}
+}
+
+func TestWithInputName(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      string
+		pols     *ast.Policies
+		expected string
+		err      error
+	}{
+		{
+			name: "allow subject user foo to manage petstore.pet where ctx.age == 13;",
+			pkg:  "foo",
+			pols: &ast.Policies{
+				Statements: []ast.Statement{
+					&ast.ActionStatement{
+						Token: token.Token{Type: token.IDENT, Literal: "allow"},
+						Action: &ast.Identifier{
+							Token: token.Token{Type: token.IDENT, Literal: "allow"},
+							Value: "allow",
+						},
+						Subject: &ast.SubjectUser{Token: token.SUBJECT, User: "foo"},
+						Verb: &ast.Identifier{
+							Token: token.Token{Type: token.IDENT, Literal: "manage"},
+							Value: "manage",
+						},
+						TypePattern: &ast.Identifier{
+							Token: token.Token{Type: token.TYPE_PATTERN, Literal: "petstore.pet"},
+							Value: "petstore.pet",
+						},
+						WhereClause: &ast.WhereClause{
+							Token: token.Token{Type: token.WHERE, Literal: "where"},
+							Condition: &ast.InfixCondition{
+								Token: token.Token{Type: token.OP_EQUAL_TO, Literal: "=="},
+								Left: &ast.Identifier{
+									Token: token.Token{Type: token.IDENT, Literal: "ctx.age"},
+									Value: "ctx.age",
+								},
+								Operator: "==",
+								Right: &ast.IntegerLiteral{
+									Token: token.Token{Type: token.INT, Literal: "13"},
+									Value: 13,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: `
+package foo
+
+default allow = false
+default deny = false
+
+base_verbs := {
+}
+
+allow {
+    seal_subject.sub == ` + "`foo`" + `
+    seal_list_contains(base_verbs[abac_input.type][` + "`manage`" + `], abac_input.verb)
+    re_match(` + "`petstore.pet`" + `, abac_input.type)
+
+    some i
+    abac_input.ctx[i]["age"] == 13
+}
+
+obligations := {
+}` + "\n" + CompiledRegoHelpers,
+		},
+	}
+
+	c, err := New()
+	if err != nil {
+		t.Fatalf("did not expect error creating backend - error: %s", err)
+	}
+	(c.(*CompilerRego)).WithInputName("abac_input")
 	var emptySwaggerTypes []types.Type
 	for idx, tst := range tests {
 		actual, err := c.Compile(tst.pkg, tst.pols, emptySwaggerTypes)

--- a/pkg/compiler/sql/sql_condition_test.go
+++ b/pkg/compiler/sql/sql_condition_test.go
@@ -140,10 +140,18 @@ func TestCompileCondition(t *testing.T) {
 		},
 		{
 			dialect:   DialectPostgres,
-			input:     `type:contacts.profile; ctx.id in "tag-manage", "tag-view"`,
+			input:     `type:contacts.profile; ctx.id in ["tag-manage", "tag-view", 123]`,
 			jsonbOp:   JSONBObjectOperator,
 			intFlag:   false,
-			expected:  ``, // TODO: expect `(ctx.id IN ('tag-manage', 'tag-view'))`,
+			expected:  `(profile.id IN ('tag-manage','tag-view',123))`,
+			shouldErr: false,
+		},
+		{
+			dialect:   DialectPostgres,
+			input:     `type:petstore.pet; "boss" in subject.groups`,
+			jsonbOp:   JSONBObjectOperator,
+			intFlag:   false,
+			expected:  ``, // TODO UNSUPPORTED; may be expected should be ('boss' IN (SELECT groups FROM subject))
 			shouldErr: true,
 		},
 	}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -32,7 +32,7 @@ func (l *Lexer) readChar() {
 }
 
 func (l *Lexer) skipWhitespace() {
-	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' || l.ch == '[' || l.ch == ']' {
+	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
 		l.readChar()
 	}
 }
@@ -48,6 +48,8 @@ func (l *Lexer) NextToken() token.Token {
 		tok.Literal = l.readComment()
 		tok.Type = token.COMMENT
 		return tok
+	case ',':
+		tok = newToken(token.COMMA, l.ch)
 	case ';':
 		tok = newToken(token.DELIMETER, l.ch)
 	case '(':
@@ -58,6 +60,10 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.OPEN_BLOCK, l.ch)
 	case '}':
 		tok = newToken(token.CLOSE_BLOCK, l.ch)
+	case '[':
+		tok = newToken(token.OPEN_SQ, l.ch)
+	case ']':
+		tok = newToken(token.CLOSE_SQ, l.ch)
 	case '"':
 		tok.Literal = l.readLiteral()
 		tok.Type = token.LITERAL
@@ -71,9 +77,11 @@ func (l *Lexer) NextToken() token.Token {
 			if isTypePattern(tok.Literal) {
 				tok.Type = token.TYPE_PATTERN
 			}
+/* TODO REMOVE ME NOT NEEDED?
 			if isLongOperator(tok.Literal) {
 				tok.Type = token.LookupOperator(tok.Literal)
 			}
+*/
 			return tok
 		}
 		if isDigit(l.ch) {
@@ -225,6 +233,7 @@ func isOperator(ch byte) bool {
 	return ch == '=' || ch == '!' || ch == '<' || ch == '>' || ch == '~'
 }
 
+/* TODO REMOVE ME NOT NEEDED?
 func isLongOperator(s string) bool {
 	switch s {
 	case token.OP_IN:
@@ -233,6 +242,7 @@ func isLongOperator(s string) bool {
 
 	return false
 }
+*/
 
 func (l *Lexer) readOperator() string {
 	start := l.position

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -15,6 +15,8 @@ func TestNextToken(t *testing.T) {
 	allow subject group customers to buy petstore.pet where ctx.tag["color"] == "purple";
 	allow subject group everyone to read petstore.pet;
         deny subject group everyone to buy petstore.pet where ctx.age < 2;
+	allow to buy petstore.pet where 2 in ctx.age;
+	allow to map gs.tuple where ctx.perm_id in [ 2, "tag-view", "tag-manage" ];
 	=== !! << >> == != < > <= >= =~ ==~ =~~
 		not and or
 	context {} to test {where ctx.age}
@@ -77,6 +79,32 @@ func TestNextToken(t *testing.T) {
 		{token.INT, "2"},
 		{token.DELIMETER, ";"},
 
+		{token.IDENT, "allow"},
+		{token.TO, "to"},
+		{token.IDENT, "buy"},
+		{token.TYPE_PATTERN, "petstore.pet"},
+		{token.WHERE, "where"},
+		{token.INT, "2"},
+		{token.OP_IN, "in"},
+		{token.TYPE_PATTERN, "ctx.age"},
+		{token.DELIMETER, ";"},
+
+		{token.IDENT, "allow"},
+		{token.TO, "to"},
+		{token.IDENT, "map"},
+		{token.TYPE_PATTERN, "gs.tuple"},
+		{token.WHERE, "where"},
+		{token.TYPE_PATTERN, "ctx.perm_id"},
+		{token.OP_IN, "in"},
+		{token.OPEN_SQ, "["},
+		{token.INT, "2"},
+		{token.COMMA, ","},
+		{token.LITERAL, "tag-view"},
+		{token.COMMA, ","},
+		{token.LITERAL, "tag-manage"},
+		{token.CLOSE_SQ, "]"},
+		{token.DELIMETER, ";"},
+
 		{token.ILLEGAL, "==="},
 		{token.ILLEGAL, "!!"},
 		{token.ILLEGAL, "<<"},
@@ -112,6 +140,7 @@ func TestNextToken(t *testing.T) {
 		}
 	}
 }
+
 func TestContextToken(t *testing.T) {
 
 	input := `

--- a/pkg/parser/condition_test.go
+++ b/pkg/parser/condition_test.go
@@ -122,6 +122,11 @@ components:
 			rules:    `allow subject group customers to buy petstore.pet where not ( (not (ctx.status == "available" and ctx.is_healthy == "true")) and (not (ctx.id == "foo" and ctx.name == "bar")) );`,
 			expected: `allow subject group customers to buy petstore.pet where (not((not((ctx.status == "available") and (ctx.is_healthy == "true"))) and (not((ctx.id == "foo") and (ctx.name == "bar")))));`,
 		},
+		{
+			name:     "in-operator array literal",
+			rules:    `allow to manage petstore.pet where ctx.status in [ "available", 2 ]`,
+			expected: `allow to manage petstore.pet where (ctx.status in ["available",2,]);`,
+		},
 	}
 
 	typs, err := types.NewTypeFromOpenAPIv3([]byte(typesContent))

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -21,6 +21,7 @@ const (
 	INT          = "INT" // 1343456
 	TYPE_PATTERN = "TYPE_PATTERN"
 	DELIMETER    = ";"
+	COMMA        = ","
 
 	// Operators
 	OP_EQUAL_TO      = "=="
@@ -35,6 +36,8 @@ const (
 	CLOSE_PAREN      = ")"
 	OPEN_BLOCK       = "{"
 	CLOSE_BLOCK      = "}"
+	OPEN_SQ          = "["
+	CLOSE_SQ         = "]"
 
 	// keywords
 	WITH    = "with"
@@ -60,6 +63,7 @@ var keywords = map[string]TokenType{
 	"and":     AND,
 	"or":      OR,
 	"context": CONTEXT,
+	"in":      OP_IN,
 }
 
 func LookupIdent(ident string) TokenType {

--- a/pkg/token/token_test.go
+++ b/pkg/token/token_test.go
@@ -68,6 +68,11 @@ func TestLookupOperator(t *testing.T) {
 			tok:      "=~",
 			expected: OP_MATCH,
 		},
+		{
+			name:     "in",
+			tok:      "in",
+			expected: OP_IN,
+		},
 	}
 
 	for _, tst := range testcases {


### PR DESCRIPTION
Also add WithInputName() method to Rego compiler

```
seal$ go test ./...
?       github.com/infobloxopen/seal    [no test files]
?       github.com/infobloxopen/seal/cmd        [no test files]
?       github.com/infobloxopen/seal/pkg/ast    [no test files]
?       github.com/infobloxopen/seal/pkg/compiler       [no test files]
?       github.com/infobloxopen/seal/pkg/compiler/error [no test files]
ok      github.com/infobloxopen/seal/pkg/compiler/rego  0.005s
ok      github.com/infobloxopen/seal/pkg/compiler/sql   0.006s
ok      github.com/infobloxopen/seal/pkg/compiler/test  0.073s
ok      github.com/infobloxopen/seal/pkg/lexer  0.028s
ok      github.com/infobloxopen/seal/pkg/parser 0.005s
ok      github.com/infobloxopen/seal/pkg/token  0.005s
ok      github.com/infobloxopen/seal/pkg/types  0.005s
```

```
seal$ make demo
./seal compile \
        -s docs/source/examples/petstore/petstore.jwt.swagger \
        -s docs/source/examples/petstore/petstore.tags.swagger \
        -s docs/source/examples/petstore/petstore.all.swagger \
        -f docs/source/examples/petstore/petstore.all.seal \
        > docs/source/examples/petstore/petstore.all.rego.compiled
INFO[0000] set logging format                            logging.format=text
INFO[0000] logging level                                 logging.level=info
cat docs/source/examples/petstore/petstore.all.rego.compiled
...
data.petstore.all.test_in: PASS (1.560397ms)
data.petstore.all.test_in_negative: PASS (983.942µs)
data.petstore.all.test_in_operator_array_literal_positive: PASS (1.124746ms)
data.petstore.all.test_in_operator_array_literal_negative: PASS (975.249µs)
data.petstore.all.test_not_operator_precedence_positive: PASS (1.342214ms)
data.petstore.all.test_not_operator_precedence_negative1: PASS (2.214561ms)
data.petstore.all.test_not_operator_precedence_negative2: PASS (1.278242ms)
data.petstore.all.test_not_operator_precedence_negative3: PASS (1.255446ms)
data.petstore.all.test_regexp: PASS (1.775894ms)
data.petstore.all.test_regexp_negative: PASS (1.41362ms)
data.petstore.all.test_ctx_usage_multiply: PASS (1.617005ms)
data.petstore.all.test_ctx_usage_negative_multi_ctx: PASS (1.473936ms)
data.petstore.all.test_ctx_usage_negative: PASS (1.899464ms)
data.petstore.all.test_use_tags: PASS (1.06174ms)
data.petstore.all.test_use_tags_negative: PASS (1.032344ms)
data.petstore.all.test_use_tags_negative_missing_endangered_tag: PASS (1.024921ms)
data.petstore.all.test_use_petstore_jwt: PASS (1.245419ms)
data.petstore.all.test_use_petstore_jwt_negative: PASS (1.231804ms)
data.petstore.all.test_banned_deny: PASS (2.269355ms)
data.petstore.all.test_banned_deny_negative: PASS (1.016172ms)
data.petstore.all.test_inspect: PASS (1.25188ms)
data.petstore.all.test_inspect_negative: PASS (1.105476ms)
data.petstore.all.test_read: PASS (1.483544ms)
data.petstore.all.test_read_negative: PASS (1.538968ms)
data.petstore.all.test_manage_cto: PASS (2.118699ms)
data.petstore.all.test_blank_subject: PASS (1.589954ms)
data.petstore.all.test_alphanumeric_identifiers: PASS (1.229516ms)
data.petstore.all.test_bench_deny_in_map_species: PASS (282.98µs)
data.petstore.all.test_bench_deny_in_map_species_2nd: PASS (282.193µs)
data.petstore.all.test_bench_deny_in_map_species_negative: PASS (242.085µs)
data.petstore.all.test_bench_deny_in_map_species_negative_2nd: PASS (244.511µs)
--------------------------------------------------------------------------------
PASS: 31/31
+ git diff --exit-code petstore.all.rego petstore.all.test_bench.rego petstore.all.test.rego
git diff --exit-code docs/source/examples/petstore
### petstore example passed REGO OPA tests
```